### PR TITLE
Require nestpy v2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pandas",
     "scipy",
     "immutabledict",
-    "nestpy == 2.0.1",
+    "nestpy == 2.0.0",
     "numba == 0.57.0",
     "awkward == 2.2.1",
     "uproot == 5.0.7",


### PR DESCRIPTION
As @HenningSE figured out, we need nestpy v2.0.1 for fuse (random seed propagation purposes), but this version bump was not included in their setup.py at the time v2.0.1 was tagged (see https://github.com/NESTCollaboration/nestpy/blob/0be624fda16969d30f6097670258108376b8e957/setup.py#L126). We then change the requirement for now to v2.0.0, until a stable release can be cloned and installed.