### PR TITLE
nestpy >= 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pandas",
     "scipy",
     "immutabledict",
-    "nestpy == 2.0.0",
+    "nestpy >= 2.0.0",
     "numba == 0.57.0",
     "awkward == 2.2.1",
     "uproot == 5.0.7",


### PR DESCRIPTION
I was too strict in https://github.com/XENONnT/fuse/pull/65. Let's also allow fuse to install itself in version beyond the (wrongly tagged) 2.0.0; see https://github.com/NESTCollaboration/nestpy/issues/103.