### PR TITLE
Deregister plugins with missing dependencies

### DIFF
--- a/fuse/context.py
+++ b/fuse/context.py
@@ -114,6 +114,8 @@ def full_chain_context(output_folder = "./fuse_data",
     # No blinding in simulations
     st.config["event_info_function"] = "disabled"
 
+    st.deregister_plugins_with_missing_dependencies()
+
     return st
 
 


### PR DESCRIPTION
After https://github.com/AxFoundation/strax/pull/775, some targets are deregistered when it is provided by a replaced plugin. Like after https://github.com/XENONnT/fuse/blob/28a2e85023e4f8069364bedc4c104533037eed89/fuse/context.py#L92, the `raw_records_aqmon` will be no longer registered, so that the `aqmon_hits` and all plugins depend on `aqmon_hits` can not find there dependencies and an error will raise.

This PR deregisters the plugins without dependencies to fix the error.

But note the configs are still not deleted so you will see something like:

```
WARNING:strax:Option hit_min_amplitude_nv not taken by any registered plugin
```

after deregistering those unnecessary plugins.