### PR TITLE
`np.bool8` to `np.bool_` because `bool8` is deprecated

### DIFF
--- a/fuse/plugins/micro_physics/detector_volumes.py
+++ b/fuse/plugins/micro_physics/detector_volumes.py
@@ -64,7 +64,7 @@ class XENONnT_TPC(VolumePlugin):
              ('z_pri', np.float32),
              ('xe_density', np.float32),
              ('vol_id', np.int8), 
-             ('create_S2', np.bool8), 
+             ('create_S2', np.bool_), 
             ]
     
     dtype = dtype + strax.time_fields
@@ -160,7 +160,7 @@ class XENONnT_BelowCathode(VolumePlugin):
              ('z_pri', np.float32),
              ('xe_density', np.float32),
              ('vol_id', np.int8), 
-             ('create_S2', np.bool8), 
+             ('create_S2', np.bool_), 
             ]
     
     dtype = dtype + strax.time_fields
@@ -256,7 +256,7 @@ class XENONnT_GasPhase(VolumePlugin):
              ('z_pri', np.float32),
              ('xe_density', np.float32),
              ('vol_id', np.int64),
-             ('create_S2', np.bool8),
+             ('create_S2', np.bool_),
             ]
     
     dtype = dtype + strax.time_fields

--- a/fuse/plugins/micro_physics/merge_cluster.py
+++ b/fuse/plugins/micro_physics/merge_cluster.py
@@ -41,7 +41,7 @@ class MergeCluster(strax.Plugin):
              ('z_pri', np.float32),
              ('xe_density', np.float32), #Will be set i a later plugin
              ('vol_id', np.int8), #Will be set i a later plugin
-             ('create_S2', np.bool8), #Will be set i a later plugin
+             ('create_S2', np.bool_), #Will be set i a later plugin
             ]
     
     dtype = dtype + strax.time_fields


### PR DESCRIPTION
When running tests with numpy==1.26.3, I got warning like:

```
fuse/plugins/micro_physics/merge_cluster.py:44
  /home/xudc/fuse/fuse/plugins/micro_physics/merge_cluster.py:44: DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)
    ('create_S2', np.bool8), #Will be set i a later plugin
```