### PR TITLE
Only install fuse, not build, docs, or tests

### DIFF
--- a/fuse/plugins/pmt_and_daq/__init__.py
+++ b/fuse/plugins/pmt_and_daq/__init__.py
@@ -7,5 +7,5 @@ from .pmt_response_and_daq import *
 from . import photon_summary
 from .photon_summary import *
 
-from .photon_pulses import *
 from . import photon_pulses
+from .photon_pulses import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,4 +36,4 @@ dependencies = [
 "Bug Tracker" = "https://github.com/XENONnT/fuse/issues"
 
 [tool.setuptools.packages.find]
-exclude = ["/plugins"]
+include = ["fuse*"]


### PR DESCRIPTION
Before this PR, the installation will install `build`, `docs`, and `tests` all in `~/.local/lib/python3.9/site-packages`. You can check this by `cat ~/.local/lib/python3.9/site-packages/fuse-0.3.0.dist-info/RECORD`. Because the `setuptools` will search every folder with `__init__.py` inside.

The new installation configuration only installs the package called `fuse`.