### PR TITLE
Changes in interpolation methods

### DIFF
--- a/fuse/plugins/detector_physics/electron_drift.py
+++ b/fuse/plugins/detector_physics/electron_drift.py
@@ -102,7 +102,7 @@ class ElectronDrift(FuseBasePlugin):
                   'SIMULATION_CONFIG_FILE.json?'
                   '&key=field_dependencies_map'
                   '&fmt=json.gz'
-                  '&method=RectBivariateSpline',
+                  '&method=WeightedNearestNeighbors',
         cache=True,
         help='Map for the electric field dependencies',
     )
@@ -122,7 +122,7 @@ class ElectronDrift(FuseBasePlugin):
                   'SIMULATION_CONFIG_FILE.json?'
                   '&key=field_distortion_comsol_map'
                   '&fmt=json.gz'
-                  '&method=RectBivariateSpline',
+                  '&method=WeightedNearestNeighbors',
         cache=True,
         help='Field distortion map used in fuse (Check if we can remove _fuse from the name)',
     )

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -220,7 +220,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
                   'SIMULATION_CONFIG_FILE.json?'
                   '&key=field_dependencies_map'
                   '&fmt=json.gz'
-                  '&method=RectBivariateSpline',
+                  '&method=WeightedNearestNeighbors',
         cache=True,
         help='Map for the electric field dependencies',
     )

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -802,7 +802,8 @@ class S2PhotonPropagationSimple(S2PhotonPropagationBase):
         default = 'itp_map://resource://simulation_config://'
                   'SIMULATION_CONFIG_FILE.json?'
                   '&key=s2_time_spline'
-                  '&fmt=json.gz',
+                  '&fmt=json.gz'
+                  '&method=RegularGridInterpolator',
         cache=True,
         help='s2_optical_propagation_spline',
     )

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -627,7 +627,8 @@ class S2PhotonPropagation(S2PhotonPropagationBase):
         default = 'itp_map://resource://simulation_config://'
                   'SIMULATION_CONFIG_FILE.json?'
                   '&key=s2_time_spline'
-                  '&fmt=json.gz',
+                  '&fmt=json.gz'
+                  '&method=RegularGridInterpolator',
         cache=True,
         help='Spline for the optical propagation of S2 signals',
     )


### PR DESCRIPTION
Currently in `straxen`, we have three interpolation methods: `RectBivariateSpline`, `RegularGridInterpolator`, `WeightedNearestNeighbors`. I propose we should avoid `RectBivariateSpline` since it creates unphysical values. The `RegularGridInterpolator` may also create unphysical values for values out of range (extrapolated), but it is faster and more straightforward than `WeightedNearestNeighbors`.

So we should use `RegularGridInterpolator` if it yields similar results to `WeightedNearestNeighbors`, and if the data are constructed on a regular bin. Otherwise we should use `WeightedNearestNeighbors`.

See [this note](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:miliu:fuse_civ_interpolation#interpolation_method_for_fuse_maps) for more plots to validate these changes.

Solves #151.

