### PR TITLE
Convert _photon_timings to integer values

### DIFF
--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -392,7 +392,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
                     positions,
                     interactions_chunk["sum_s2_photons"],
                     _photon_channels,
-                )
+                ).astype(np.int64)
 
                 # Repeat for n photons per electron # Should this be before adding delays?
                 _photon_timings += np.repeat(electron_group["time"], electron_group["n_s2_photons"])
@@ -465,7 +465,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
             positions,
             interactions_chunk["sum_s2_photons"],
             _photon_channels,
-        )
+        ).astype(np.int64)
 
         _photon_timings += np.repeat(electron_group["time"], electron_group["n_s2_photons"])
 

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -32,7 +32,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
     Note: The timing calculation is defined in the child plugin.
     """
 
-    __version__ = "0.3.0"
+    __version__ = "0.3.1"
 
     depends_on = (
         "electron_time",


### PR DESCRIPTION
This PR fixes https://github.com/XENONnT/fuse/issues/86. It turned out that the problem was caused by the addition of int64 values to float64 values for the timing. 

The first plot shows the electron and s2 photon times before the fix: 
![photon_timing_previous](https://github.com/XENONnT/fuse/assets/27280678/2d5d5d61-27c1-43ba-a90a-452d430a14bb)

After the fix the times are not spaced in these discrete steps: 
![Photon_timing_fixed](https://github.com/XENONnT/fuse/assets/27280678/fedd8985-7d7b-40c9-b767-a862c5a63331)
