### PR TITLE
Avoid duplicate code in downchunking

### DIFF
--- a/docs/source/plugins/pmt_and_daq/PMTResponseAndDAQ.rst
+++ b/docs/source/plugins/pmt_and_daq/PMTResponseAndDAQ.rst
@@ -20,7 +20,7 @@ Technical Details
    depends_on = ("photon_summary", "pulse_ids", "pulse_windows")
    provides = "raw_records"
    data_kind = "raw_records"
-   __version__ = "0.1.3"
+   __version__ = "0.1.4"
 
 Provided Columns
 ================

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -347,7 +347,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
         last_start = start
         if n_chunks > 1:
             for electron_group in electron_chunks[:-1]:
-                result = self.compute_chunk(electron_group, interactions_in_roi, mask)
+                result = self.compute_chunk(interactions_in_roi, mask, electron_group)
 
                 # Move the chunk bound 90% of the minimal gap length to
                 # the next photon to make space for afterpluses
@@ -360,12 +360,12 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
 
         # And the last chunk
         electron_group = electron_chunks[-1]
-        result = self.compute_chunk(electron_group, interactions_in_roi, mask)
+        result = self.compute_chunk(interactions_in_roi, mask, electron_group)
 
         chunk = self.chunk(start=last_start, end=end, data=result)
         yield chunk
 
-    def compute_chunk(self, electron_group, interactions_in_roi, mask):
+    def compute_chunk(self, interactions_in_roi, mask, electron_group):
         unique_clusters_in_group = np.unique(electron_group["cluster_id"])
         interactions_chunk = interactions_in_roi[mask][
             np.isin(interactions_in_roi["cluster_id"][mask], unique_clusters_in_group)

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -483,7 +483,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
 
         chunk = self.chunk(start=last_start, end=end, data=result)
         yield chunk
-    
+
     def compute_chunk(self, interactions_in_roi, mask):
         unique_clusters_in_group = np.unique(electron_group["cluster_id"])
         interactions_chunk = interactions_in_roi[mask][

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -483,6 +483,73 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
 
         chunk = self.chunk(start=last_start, end=end, data=result)
         yield chunk
+    
+    def compute_chunk(self, interactions_in_roi, mask):
+        unique_clusters_in_group = np.unique(electron_group["cluster_id"])
+        interactions_chunk = interactions_in_roi[mask][
+            np.isin(interactions_in_roi["cluster_id"][mask], unique_clusters_in_group)
+        ]
+
+        # Sort both the interactions and the electrons by cluster_id
+        # We will later sort by time again when yielding the data.
+        sort_index_ic = np.argsort(interactions_chunk["cluster_id"])
+        sort_index_eg = np.argsort(electron_group["cluster_id"])
+        interactions_chunk = interactions_chunk[sort_index_ic]
+        electron_group = electron_group[sort_index_eg]
+
+        positions = np.array([interactions_chunk["x_obs"], interactions_chunk["y_obs"]]).T
+
+        _photon_channels = self.photon_channels(
+            interactions_chunk["n_electron_extracted"],
+            interactions_chunk["z_obs"],
+            positions,
+            interactions_chunk["drift_time_mean"],
+            interactions_chunk["sum_s2_photons"],
+        )
+
+        _photon_timings = self.photon_timings(
+            positions,
+            interactions_chunk["sum_s2_photons"],
+            _photon_channels,
+        ).astype(np.int64)
+
+        # Repeat for n photons per electron # Should this be before adding delays?
+        _photon_timings += np.repeat(electron_group["time"], electron_group["n_s2_photons"])
+
+        _cluster_id = np.repeat(
+            interactions_chunk["cluster_id"], interactions_chunk["sum_s2_photons"]
+        )
+
+        # Do i want to save both -> timings with and without pmt transit time spread?
+        # Correct for PMT Transit Time Spread
+        _photon_timings = pmt_transit_time_spread(
+            _photon_timings=_photon_timings,
+            pmt_transit_time_mean=self.pmt_transit_time_mean,
+            pmt_transit_time_spread=self.pmt_transit_time_spread,
+            rng=self.rng,
+        )
+
+        _photon_gains, _photon_is_dpe = photon_gain_calculation(
+            _photon_channels=_photon_channels,
+            p_double_pe_emision=self.p_double_pe_emision,
+            gains=self.gains,
+            spe_scaling_factor_distributions=self.spe_scaling_factor_distributions,
+            rng=self.rng,
+        )
+
+        result = build_photon_propagation_output(
+            dtype=self.dtype,
+            _photon_timings=_photon_timings,
+            _photon_channels=_photon_channels,
+            _photon_gains=_photon_gains,
+            _photon_is_dpe=_photon_is_dpe,
+            _cluster_id=_cluster_id,
+            photon_type=2,
+        )
+
+        result = strax.sort_by_time(result)
+
+        return result
 
     def photon_channels(self, n_electron, z_obs, positions, drift_time_mean, n_photons):
         channels = np.arange(self.n_tpc_pmts).astype(np.int64)

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -347,69 +347,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
         last_start = start
         if n_chunks > 1:
             for electron_group in electron_chunks[:-1]:
-                unique_clusters_in_group = np.unique(electron_group["cluster_id"])
-                interactions_chunk = interactions_in_roi[mask][
-                    np.isin(interactions_in_roi["cluster_id"][mask], unique_clusters_in_group)
-                ]
-
-                # Sort both the interactions and the electrons by cluster_id
-                # We will later sort by time again when yielding the data.
-                sort_index_ic = np.argsort(interactions_chunk["cluster_id"])
-                sort_index_eg = np.argsort(electron_group["cluster_id"])
-                interactions_chunk = interactions_chunk[sort_index_ic]
-                electron_group = electron_group[sort_index_eg]
-
-                positions = np.array([interactions_chunk["x_obs"], interactions_chunk["y_obs"]]).T
-
-                _photon_channels = self.photon_channels(
-                    interactions_chunk["n_electron_extracted"],
-                    interactions_chunk["z_obs"],
-                    positions,
-                    interactions_chunk["drift_time_mean"],
-                    interactions_chunk["sum_s2_photons"],
-                )
-
-                _photon_timings = self.photon_timings(
-                    positions,
-                    interactions_chunk["sum_s2_photons"],
-                    _photon_channels,
-                ).astype(np.int64)
-
-                # Repeat for n photons per electron # Should this be before adding delays?
-                _photon_timings += np.repeat(electron_group["time"], electron_group["n_s2_photons"])
-
-                _cluster_id = np.repeat(
-                    interactions_chunk["cluster_id"], interactions_chunk["sum_s2_photons"]
-                )
-
-                # Do i want to save both -> timings with and without pmt transit time spread?
-                # Correct for PMT Transit Time Spread
-                _photon_timings = pmt_transit_time_spread(
-                    _photon_timings=_photon_timings,
-                    pmt_transit_time_mean=self.pmt_transit_time_mean,
-                    pmt_transit_time_spread=self.pmt_transit_time_spread,
-                    rng=self.rng,
-                )
-
-                _photon_gains, _photon_is_dpe = photon_gain_calculation(
-                    _photon_channels=_photon_channels,
-                    p_double_pe_emision=self.p_double_pe_emision,
-                    gains=self.gains,
-                    spe_scaling_factor_distributions=self.spe_scaling_factor_distributions,
-                    rng=self.rng,
-                )
-
-                result = build_photon_propagation_output(
-                    dtype=self.dtype,
-                    _photon_timings=_photon_timings,
-                    _photon_channels=_photon_channels,
-                    _photon_gains=_photon_gains,
-                    _photon_is_dpe=_photon_is_dpe,
-                    _cluster_id=_cluster_id,
-                    photon_type=2,
-                )
-
-                result = strax.sort_by_time(result)
+                result = self.compute_chunk(electron_group, interactions_in_roi, mask)
 
                 # Move the chunk bound 90% of the minimal gap length to
                 # the next photon to make space for afterpluses
@@ -422,64 +360,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
 
         # And the last chunk
         electron_group = electron_chunks[-1]
-        unique_clusters_in_group = np.unique(electron_group["cluster_id"])
-        interactions_chunk = interactions_in_roi[mask][
-            np.isin(interactions_in_roi["cluster_id"][mask], unique_clusters_in_group)
-        ]
-
-        sort_index_ic = np.argsort(interactions_chunk["cluster_id"])
-        sort_index_eg = np.argsort(electron_group["cluster_id"])
-        interactions_chunk = interactions_chunk[sort_index_ic]
-        electron_group = electron_group[sort_index_eg]
-
-        positions = np.array([interactions_chunk["x_obs"], interactions_chunk["y_obs"]]).T
-
-        _photon_channels = self.photon_channels(
-            interactions_chunk["n_electron_extracted"],
-            interactions_chunk["z_obs"],
-            positions,
-            interactions_chunk["drift_time_mean"],
-            interactions_chunk["sum_s2_photons"],
-        )
-
-        _photon_timings = self.photon_timings(
-            positions,
-            interactions_chunk["sum_s2_photons"],
-            _photon_channels,
-        ).astype(np.int64)
-
-        _photon_timings += np.repeat(electron_group["time"], electron_group["n_s2_photons"])
-
-        _cluster_id = np.repeat(
-            interactions_chunk["cluster_id"], interactions_chunk["sum_s2_photons"]
-        )
-
-        _photon_timings = pmt_transit_time_spread(
-            _photon_timings=_photon_timings,
-            pmt_transit_time_mean=self.pmt_transit_time_mean,
-            pmt_transit_time_spread=self.pmt_transit_time_spread,
-            rng=self.rng,
-        )
-
-        _photon_gains, _photon_is_dpe = photon_gain_calculation(
-            _photon_channels=_photon_channels,
-            p_double_pe_emision=self.p_double_pe_emision,
-            gains=self.gains,
-            spe_scaling_factor_distributions=self.spe_scaling_factor_distributions,
-            rng=self.rng,
-        )
-
-        result = build_photon_propagation_output(
-            dtype=self.dtype,
-            _photon_timings=_photon_timings,
-            _photon_channels=_photon_channels,
-            _photon_gains=_photon_gains,
-            _photon_is_dpe=_photon_is_dpe,
-            _cluster_id=_cluster_id,
-            photon_type=2,
-        )
-
-        result = strax.sort_by_time(result)
+        result = self.compute_chunk(electron_group, interactions_in_roi, mask)
 
         chunk = self.chunk(start=last_start, end=end, data=result)
         yield chunk

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -32,7 +32,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
     Note: The timing calculation is defined in the child plugin.
     """
 
-    __version__ = "0.3.1"
+    __version__ = "0.3.2"
 
     depends_on = (
         "electron_time",

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -365,7 +365,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
         chunk = self.chunk(start=last_start, end=end, data=result)
         yield chunk
 
-    def compute_chunk(self, interactions_in_roi, mask):
+    def compute_chunk(self, electron_group, interactions_in_roi, mask):
         unique_clusters_in_group = np.unique(electron_group["cluster_id"])
         interactions_chunk = interactions_in_roi[mask][
             np.isin(interactions_in_roi["cluster_id"][mask], unique_clusters_in_group)

--- a/fuse/plugins/pmt_and_daq/pmt_response_and_daq.py
+++ b/fuse/plugins/pmt_and_daq/pmt_response_and_daq.py
@@ -258,7 +258,7 @@ class PMTResponseAndDAQ(FuseBaseDownChunkingPlugin):
         records = self.compute_chunk(_photons, unique_photon_pulse_ids, pulse_window_chunks[-1])
         chunk = self.chunk(start=last_start, end=end, data=records)
         yield chunk
-    
+
     def compute_chunk(self, _photons, unique_photon_pulse_ids, pulse_group):
         # use an upper limit for the waveform buffer
         length_waveform_buffer = np.int32(

--- a/fuse/plugins/pmt_and_daq/pmt_response_and_daq.py
+++ b/fuse/plugins/pmt_and_daq/pmt_response_and_daq.py
@@ -248,48 +248,26 @@ class PMTResponseAndDAQ(FuseBaseDownChunkingPlugin):
 
         if n_chunks > 1:
             for pulse_group in pulse_window_chunks[:-1]:
-                # use an upper limit for the waveform buffer
-                length_waveform_buffer = np.int32(
-                    np.sum(np.ceil(pulse_group["length"] / strax.DEFAULT_RECORD_LENGTH))
-                )
-                waveform_buffer = np.zeros(length_waveform_buffer, dtype=self.dtype)
-
-                buffer_level = build_waveform(
-                    pulse_group,
-                    _photons,
-                    unique_photon_pulse_ids,
-                    waveform_buffer,
-                    self.dt,
-                    self._pmt_current_templates,
-                    self.current_2_adc,
-                    self.noise_data["arr_0"],
-                    self.enable_noise,
-                    self.digitizer_reference_baseline,
-                    self.thresholds,
-                    self.trigger_window,
-                )
-
-                records = waveform_buffer[:buffer_level]
-
-                # Digitzier saturation
-                # Clip negative values to 0
-                records["data"][records["data"] < 0] = 0
-
-                records = strax.sort_by_time(records)
-
+                records = self.compute_chunk(_photons, unique_photon_pulse_ids, pulse_group)
                 chunk_end = np.max(strax.endtime(records))
                 chunk = self.chunk(start=last_start, end=chunk_end, data=records)
                 last_start = chunk_end
                 yield chunk
 
         # And the last chunk
+        records = self.compute_chunk(_photons, unique_photon_pulse_ids, pulse_window_chunks[-1])
+        chunk = self.chunk(start=last_start, end=end, data=records)
+        yield chunk
+    
+    def compute_chunk(self, _photons, unique_photon_pulse_ids, pulse_group):
+        # use an upper limit for the waveform buffer
         length_waveform_buffer = np.int32(
-            np.sum(np.ceil(pulse_window_chunks[-1]["length"] / strax.DEFAULT_RECORD_LENGTH))
+            np.sum(np.ceil(pulse_group["length"] / strax.DEFAULT_RECORD_LENGTH))
         )
         waveform_buffer = np.zeros(length_waveform_buffer, dtype=self.dtype)
 
         buffer_level = build_waveform(
-            pulse_window_chunks[-1],
+            pulse_group,
             _photons,
             unique_photon_pulse_ids,
             waveform_buffer,
@@ -308,11 +286,9 @@ class PMTResponseAndDAQ(FuseBaseDownChunkingPlugin):
         # Digitzier saturation
         # Clip negative values to 0
         records["data"][records["data"] < 0] = 0
-
         records = strax.sort_by_time(records)
 
-        chunk = self.chunk(start=last_start, end=end, data=records)
-        yield chunk
+        return records
 
     def init_pmt_current_templates(self):
         """Create spe templates, for 10ns sample duration and 1ns rounding we

--- a/fuse/plugins/pmt_and_daq/pmt_response_and_daq.py
+++ b/fuse/plugins/pmt_and_daq/pmt_response_and_daq.py
@@ -26,7 +26,7 @@ class PMTResponseAndDAQ(FuseBaseDownChunkingPlugin):
     length (if needed). Finally the data is saved as raw_records.
     """
 
-    __version__ = "0.1.3"
+    __version__ = "0.1.4"
 
     depends_on = ("photon_summary", "pulse_ids", "pulse_windows")
 

--- a/tests/test_DetectorPhysics_csv.py
+++ b/tests/test_DetectorPhysics_csv.py
@@ -6,7 +6,7 @@ import timeout_decorator
 import fuse
 from _utils import build_random_instructions
 
-TIMEOUT = 240
+TIMEOUT = 360
 
 
 class TestDetectorPhysicsCsv(unittest.TestCase):

--- a/tests/test_DetectorPhysics_csv.py
+++ b/tests/test_DetectorPhysics_csv.py
@@ -6,7 +6,7 @@ import timeout_decorator
 import fuse
 from _utils import build_random_instructions
 
-TIMEOUT = 360
+TIMEOUT = 240
 
 
 class TestDetectorPhysicsCsv(unittest.TestCase):


### PR DESCRIPTION
In the previous code, the `compute` function for downchunking plugins (S2PhotonPropagationBase, PMTResponseAndDAQ) has some duplicate code. While I understand this is because the chunking start/end times are different, it can be avoided by defining a function `compute_chunk`, and calling it to calculate the data in each chunk.

This PR should not alter the behavior of fuse and should be purely cosmetic. If the simulation results change, please let me know.