### PR TITLE
Add a dtypes manger

### DIFF
--- a/examples/5_Simulation_Truth.ipynb
+++ b/examples/5_Simulation_Truth.ipynb
@@ -391,7 +391,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ms_with_tagged_clusters_cut = ms_with_tagged_clusters.query(\"evtid == 1 & in_main_s2 == True\")\n",
+    "ms_with_tagged_clusters_cut = ms_with_tagged_clusters.query(\"eventid == 1 & in_main_s2 == True\")\n",
     "ms_with_tagged_clusters_cut[[\"ed\", \"sum_s2_photons\", \"photons_in_main_s2\"]].head(10)"
    ]
   }

--- a/fuse/__init__.py
+++ b/fuse/__init__.py
@@ -1,5 +1,8 @@
 __version__ = "1.2.0"
 
+from . import dtypes
+from .dtypes import *
+
 from . import plugins
 from .plugins import *
 

--- a/fuse/dtypes.py
+++ b/fuse/dtypes.py
@@ -1,0 +1,64 @@
+import numpy as np
+
+
+g4_fields = [
+    (("Time with respect to the start of the event [ns]", "t"), np.float64),
+    (("Energy deposit [keV]", "ed"), np.float32),
+    (("Particle type", "type"), "<U18"),
+    (("Geant4 track ID", "trackid"), np.int16),
+    (("Particle type of the parent particle", "parenttype"), "<U18"),
+    (("Trackid of the parent particle", "parentid"), np.int16),
+    (("Geant4 process creating the particle", "creaproc"), "<U25"),
+    (("Geant4 process responsible for the energy deposit", "edproc"), "<U25"),
+    (("Geant4 event ID", "evtid"), np.int32),
+]
+
+
+primary_positions_fields = [
+    (("x position of the primary particle [cm]", "x_pri"), np.float32),
+    (("y position of the primary particle [cm]", "y_pri"), np.float32),
+    (("z position of the primary particle [cm]", "z_pri"), np.float32),
+]
+
+
+deposit_positions_fields = [
+    (("x position of the energy deposit [cm]", "x"), np.float32),
+    (("y position of the energy deposit [cm]", "y"), np.float32),
+    (("z position of the energy deposit [cm]", "z"), np.float32),
+]
+
+
+cluster_positions_fields = [
+    (("x position of the cluster [cm]", "x"), np.float32),
+    (("y position of the cluster [cm]", "y"), np.float32),
+    (("z position of the cluster [cm]", "z"), np.float32),
+]
+
+
+cluster_id_fields = [
+    (("Energy of the cluster [keV]", "ed"), np.float32),
+    (("NEST interaction type", "nestid"), np.int8),
+    (("ID of the cluster", "cluster_id"), np.int32),
+]
+
+
+cluster_misc_fields = [
+    (("Mass number of the interacting particle", "A"), np.int8),
+    (("Charge number of the interacting particle", "Z"), np.int8),
+    (("Geant4 event ID", "evtid"), np.int32),
+    (("Xenon density at the cluster position. Will be set later", "xe_density"), np.float32),
+    (("ID of the volume in which the cluster occured. Will be set later", "vol_id"), np.int8),
+    (("Flag indicating if a cluster can create a S2 signal", "create_S2"), np.bool_),
+]
+
+
+quanta_fields = [
+    (("Number of photons at interaction position", "photons"), np.int32),
+    (("Number of electrons at interaction position", "electrons"), np.int32),
+    (("Number of excitons at interaction position", "excitons"), np.int32),
+]
+
+
+electric_fields = [
+    (("Electric field value at the cluster position [V/cm]", "e_field"), np.float32),
+]

--- a/fuse/dtypes.py
+++ b/fuse/dtypes.py
@@ -41,6 +41,11 @@ cluster_id_fields = [
     (("ID of the cluster", "cluster_id"), np.int32),
 ]
 
+csv_cluster_misc_fields = [
+    (("Time of the interaction", "t"), np.int64),
+    (("Geant4 event ID", "eventid"), np.int32),
+]
+
 
 cluster_misc_fields = [
     (("Mass number of the interacting particle", "A"), np.int8),

--- a/fuse/dtypes.py
+++ b/fuse/dtypes.py
@@ -2,7 +2,7 @@ import numpy as np
 
 
 g4_fields = [
-    (("Time with respect to the start of the event [ns]", "t"), np.float64),
+    (("Time with respect to the start of the event [ns]", "t"), np.int64),
     (("Energy deposit [keV]", "ed"), np.float32),
     (("Particle type", "type"), "<U18"),
     (("Geant4 track ID", "trackid"), np.int16),

--- a/fuse/dtypes.py
+++ b/fuse/dtypes.py
@@ -67,3 +67,12 @@ quanta_fields = [
 electric_fields = [
     (("Electric field value at the cluster position [V/cm]", "e_field"), np.float32),
 ]
+
+
+propagated_photons_fields = [
+    (("PMT channel of the photon", "channel"), np.int16),
+    (("Photon creates a double photo-electron emission", "dpe"), np.bool_),
+    (("Sampled PMT gain for the photon", "photon_gain"), np.int32),
+    (("ID of the cluster creating the photon", "cluster_id"), np.int32),
+    (("Type of the photon. S1 (1), S2 (2) or PMT AP (0)", "photon_type"), np.int8),
+]

--- a/fuse/dtypes.py
+++ b/fuse/dtypes.py
@@ -46,8 +46,8 @@ cluster_misc_fields = [
     (("Mass number of the interacting particle", "A"), np.int8),
     (("Charge number of the interacting particle", "Z"), np.int8),
     (("Geant4 event ID", "evtid"), np.int32),
-    (("Xenon density at the cluster position. Will be set later", "xe_density"), np.float32),
-    (("ID of the volume in which the cluster occured. Will be set later", "vol_id"), np.int8),
+    (("Xenon density at the cluster position", "xe_density"), np.float32),
+    (("ID of the volume in which the cluster occured", "vol_id"), np.int8),
     (("Flag indicating if a cluster can create a S2 signal", "create_S2"), np.bool_),
 ]
 

--- a/fuse/dtypes.py
+++ b/fuse/dtypes.py
@@ -10,7 +10,7 @@ g4_fields = [
     (("Trackid of the parent particle", "parentid"), np.int16),
     (("Geant4 process creating the particle", "creaproc"), "<U25"),
     (("Geant4 process responsible for the energy deposit", "edproc"), "<U25"),
-    (("Geant4 event ID", "evtid"), np.int32),
+    (("Geant4 event ID", "eventid"), np.int32),
 ]
 
 
@@ -50,7 +50,7 @@ csv_cluster_misc_fields = [
 cluster_misc_fields = [
     (("Mass number of the interacting particle", "A"), np.int8),
     (("Charge number of the interacting particle", "Z"), np.int8),
-    (("Geant4 event ID", "evtid"), np.int32),
+    (("Geant4 event ID", "eventid"), np.int32),
     (("Xenon density at the cluster position", "xe_density"), np.float32),
     (("ID of the volume in which the cluster occured", "vol_id"), np.int8),
     (("Flag indicating if a cluster can create a S2 signal", "create_S2"), np.bool_),

--- a/fuse/plugins/detector_physics/csv_input.py
+++ b/fuse/plugins/detector_physics/csv_input.py
@@ -6,6 +6,7 @@ import pandas as pd
 import strax
 import straxen
 
+from ...dtypes import cluster_positions_fields, cluster_id_fields, quanta_fields, electric_fields
 from ...common import dynamic_chunking
 from ...plugin import FuseBasePlugin
 
@@ -30,19 +31,13 @@ class ChunkCsvInput(FuseBasePlugin):
 
     source_done = False
 
-    dtype = [
-        (("x position of the cluster [cm]", "x"), np.float32),
-        (("y position of the cluster [cm]", "y"), np.float32),
-        (("z position of the cluster [cm]", "z"), np.float32),
-        (("Number of photons at interaction position", "photons"), np.int32),
-        (("Number of electrons at interaction position", "electrons"), np.int32),
-        (("Number of excitons at interaction position", "excitons"), np.int32),
-        (("Electric field value at the cluster position [V/cm]", "e_field"), np.float32),
-        (("Energy of the cluster [keV]", "ed"), np.float32),
-        (("NEST interaction type", "nestid"), np.int8),
-        (("ID of the cluster", "cluster_id"), np.int32),
-    ]
-    dtype = dtype + strax.time_fields
+    dtype = (
+        cluster_positions_fields
+        + quanta_fields
+        + electric_fields
+        + cluster_id_fields
+        + strax.time_fields
+    )
 
     # Config options
     input_file = straxen.URLConfig(
@@ -140,26 +135,22 @@ class csv_file_loader:
         self.first_chunk_left = np.int64(first_chunk_left)
         self.debug = debug
 
-        self.dtype = [
-            (("x position of the cluster [cm]", "x"), np.float32),
-            (("y position of the cluster [cm]", "y"), np.float32),
-            (("z position of the cluster [cm]", "z"), np.float32),
-            (("Number of photons at interaction position", "photons"), np.int32),
-            (("Number of electrons at interaction position", "electrons"), np.int32),
-            (("Number of excitons at interaction position", "excitons"), np.int32),
-            (("Electric field value at the cluster position [V/cm]", "e_field"), np.float32),
-            (("Energy of the cluster [keV]", "ed"), np.float32),
-            (("NEST interaction type", "nestid"), np.int8),
-            (("ID of the cluster", "cluster_id"), np.int32),
-            (
-                ("Time of the interaction", "t"),
-                np.int64,
-            ),  # Remove them later as they are not in the usual micropyhsics summary
-            (
-                ("Geant4 event ID", "eventid"),
-                np.int32,
-            ),  # Remove them later as they are not in the usual micropyhsics summary
-        ]
+        self.dtype = (
+            cluster_positions_fields
+            + quanta_fields
+            + electric_fields
+            + cluster_id_fields
+            + [
+                (
+                    ("Time of the interaction", "t"),
+                    np.int64,
+                ),  # Remove them later as they are not in the usual micropyhsics summary
+                (
+                    ("Geant4 event ID", "eventid"),
+                    np.int32,
+                ),  # Remove them later as they are not in the usual micropyhsics summary
+            ]
+        )
         self.dtype = self.dtype + strax.time_fields
 
         # The csv file needs to have these columns:

--- a/fuse/plugins/detector_physics/csv_input.py
+++ b/fuse/plugins/detector_physics/csv_input.py
@@ -151,23 +151,9 @@ class csv_file_loader:
                 ),  # Remove them later as they are not in the usual micropyhsics summary
             ]
         )
-        self.dtype = self.dtype + strax.time_fields
-
         # The csv file needs to have these columns:
-        self.columns = [
-            "x",
-            "y",
-            "z",
-            "photons",
-            "electrons",
-            "excitons",
-            "e_field",
-            "ed",
-            "nestid",
-            "t",
-            "eventid",
-            "cluster_id",
-        ]
+        self.columns = list(np.dtype(self.dtype).names)
+        self.dtype += strax.time_fields
 
     def output_chunk(self):
         instructions, n_simulated_events = self.__load_csv_file()

--- a/fuse/plugins/detector_physics/csv_input.py
+++ b/fuse/plugins/detector_physics/csv_input.py
@@ -220,9 +220,11 @@ class csv_file_loader:
         log.debug("Load detector simulation instructions from a csv file!")
         df = pd.read_csv(self.input_file)
 
+        missing_columns = set(self.columns) - set(df.columns)
+
         # Check if all needed columns are in place:
-        if not set(self.columns).issubset(df.columns):
-            log.warning("Not all needed columns provided!")
+        if missing_columns:
+            raise ValueError(f"Not all needed columns provided! {missing_columns} are missing.")
 
         n_simulated_events = len(np.unique(df.eventid))
 

--- a/fuse/plugins/detector_physics/delayed_electrons/delayed_electrons_s1photonhits.py
+++ b/fuse/plugins/detector_physics/delayed_electrons/delayed_electrons_s1photonhits.py
@@ -22,8 +22,7 @@ class S1PhotonHitsEmpty(FuseBasePlugin):
 
     dtype = [
         (("Number detected S1 photons", "n_s1_photon_hits"), np.int32),
-    ]
-    dtype = dtype + strax.time_fields
+    ] + strax.time_fields
 
     def compute(self, delayed_interactions_in_roi):
         result = np.zeros(len(delayed_interactions_in_roi), dtype=self.dtype)

--- a/fuse/plugins/detector_physics/electron_drift.py
+++ b/fuse/plugins/detector_physics/electron_drift.py
@@ -43,8 +43,7 @@ class ElectronDrift(FuseBasePlugin):
             ("Observed z position of the cluster after field distortion correction [cm]", "z_obs"),
             np.float32,
         ),
-    ]
-    dtype = dtype + strax.time_fields
+    ] + strax.time_fields
 
     save_when = strax.SaveWhen.ALWAYS
 

--- a/fuse/plugins/detector_physics/electron_extraction.py
+++ b/fuse/plugins/detector_physics/electron_extraction.py
@@ -27,9 +27,7 @@ class ElectronExtraction(FuseBasePlugin):
 
     dtype = [
         (("Number of electrons extracted into the gas phase", "n_electron_extracted"), np.int32),
-    ]
-
-    dtype = dtype + strax.time_fields
+    ] + strax.time_fields
 
     # Config options
     s2_secondary_sc_gain_mc = straxen.URLConfig(

--- a/fuse/plugins/detector_physics/electron_timing.py
+++ b/fuse/plugins/detector_physics/electron_timing.py
@@ -32,8 +32,7 @@ class ElectronTiming(FuseBasePlugin):
         (("x position of the electron [cm]", "x"), np.float32),
         (("y position of the electron [cm]", "y"), np.float32),
         (("ID of the cluster creating the electron", "cluster_id"), np.int32),
-    ]
-    dtype = dtype + strax.time_fields
+    ] + strax.time_fields
 
     # Config options
     electron_trapping_time = straxen.URLConfig(

--- a/fuse/plugins/detector_physics/s1_photon_hits.py
+++ b/fuse/plugins/detector_physics/s1_photon_hits.py
@@ -29,8 +29,7 @@ class S1PhotonHits(FuseBasePlugin):
 
     dtype = [
         (("Number detected S1 photons", "n_s1_photon_hits"), np.int32),
-    ]
-    dtype = dtype + strax.time_fields
+    ] + strax.time_fields
 
     # Config options
     pmt_circuit_load_resistor = straxen.URLConfig(

--- a/fuse/plugins/detector_physics/s1_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s1_photon_propagation.py
@@ -46,8 +46,7 @@ class S1PhotonPropagationBase(FuseBasePlugin):
         (("Sampled PMT gain for the photon", "photon_gain"), np.int32),
         (("ID of the cluster creating the photon", "cluster_id"), np.int32),
         (("Type of the photon. S1 (1), S2 (2) or PMT AP (0)", "photon_type"), np.int8),
-    ]
-    dtype = dtype + strax.time_fields
+    ] + strax.time_fields
 
     # Config options shared by S1 and S2 simulation
     p_double_pe_emision = straxen.URLConfig(

--- a/fuse/plugins/detector_physics/s1_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s1_photon_propagation.py
@@ -5,6 +5,7 @@ import nestpy
 import strax
 import straxen
 
+from ...dtypes import propagated_photons_fields
 from ...common import pmt_gains, build_photon_propagation_output
 from ...common import (
     init_spe_scaling_factor_distributions,
@@ -40,13 +41,7 @@ class S1PhotonPropagationBase(FuseBasePlugin):
 
     save_when = strax.SaveWhen.TARGET
 
-    dtype = [
-        (("PMT channel of the photon", "channel"), np.int16),
-        (("Photon creates a double photo-electron emission", "dpe"), np.bool_),
-        (("Sampled PMT gain for the photon", "photon_gain"), np.int32),
-        (("ID of the cluster creating the photon", "cluster_id"), np.int32),
-        (("Type of the photon. S1 (1), S2 (2) or PMT AP (0)", "photon_type"), np.int8),
-    ] + strax.time_fields
+    dtype = propagated_photons_fields + strax.time_fields
 
     # Config options shared by S1 and S2 simulation
     p_double_pe_emision = straxen.URLConfig(

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -7,6 +7,7 @@ from numba import njit
 from scipy.stats import skewnorm
 from scipy import constants
 
+from ...dtypes import propagated_photons_fields
 from ...common import pmt_gains, build_photon_propagation_output
 from ...common import (
     init_spe_scaling_factor_distributions,
@@ -48,13 +49,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
 
     save_when = strax.SaveWhen.TARGET
 
-    dtype = [
-        (("PMT channel of the photon", "channel"), np.int16),
-        (("Photon creates a double photo-electron emission", "dpe"), np.bool_),
-        (("Sampled PMT gain for the photon", "photon_gain"), np.int32),
-        (("ID of the cluster creating the photon", "cluster_id"), np.int32),
-        (("Type of the photon. S1 (1), S2 (2) or PMT AP (0)", "photon_type"), np.int8),
-    ] + strax.time_fields
+    dtype = propagated_photons_fields + strax.time_fields
 
     # Config options shared by S1 and S2 simulation
     p_double_pe_emision = straxen.URLConfig(

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -54,8 +54,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
         (("Sampled PMT gain for the photon", "photon_gain"), np.int32),
         (("ID of the cluster creating the photon", "cluster_id"), np.int32),
         (("Type of the photon. S1 (1), S2 (2) or PMT AP (0)", "photon_type"), np.int8),
-    ]
-    dtype = dtype + strax.time_fields
+    ] + strax.time_fields
 
     # Config options shared by S1 and S2 simulation
     p_double_pe_emision = straxen.URLConfig(

--- a/fuse/plugins/micro_physics/detector_volumes.py
+++ b/fuse/plugins/micro_physics/detector_volumes.py
@@ -1,8 +1,13 @@
 import strax
-import numpy as np
 import straxen
 import logging
 
+from ...dtypes import (
+    primary_positions_fields,
+    cluster_positions_fields,
+    cluster_id_fields,
+    cluster_misc_fields,
+)
 from ...volume_plugin import VolumePlugin
 from ...vertical_merger_plugin import VerticalMergerPlugin
 
@@ -37,32 +42,19 @@ class XENONnT_TPC(VolumePlugin):
     to ``True``.
     """
 
+    __version__ = "0.3.2"
     depends_on = "clustered_interactions"
-
     provides = "tpc_interactions"
     data_kind = "tpc_interactions"
-    __version__ = "0.3.1"
 
     # Can we import this from MergeCluster and just add the needed fields?
-    dtype = [
-        (("x position of the cluster [cm]", "x"), np.float32),
-        (("y position of the cluster [cm]", "y"), np.float32),
-        (("z position of the cluster [cm]", "z"), np.float32),
-        (("Energy of the cluster [keV]", "ed"), np.float32),
-        (("NEST interaction type", "nestid"), np.int8),
-        (("Mass number of the interacting particle", "A"), np.int8),
-        (("Charge number of the interacting particle", "Z"), np.int8),
-        (("Geant4 event ID", "evtid"), np.int32),
-        (("x position of the primary particle [cm]", "x_pri"), np.float32),
-        (("y position of the primary particle [cm]", "y_pri"), np.float32),
-        (("z position of the primary particle [cm]", "z_pri"), np.float32),
-        (("ID of the cluster", "cluster_id"), np.int32),
-        (("Xenon density at the cluster position", "xe_density"), np.float32),
-        (("ID of the volume in which the cluster occured", "vol_id"), np.int8),
-        (("Flag indicating if a cluster can create a S2 signal", "create_S2"), np.bool_),
-    ]
-
-    dtype = dtype + strax.time_fields
+    dtype = (
+        cluster_positions_fields
+        + cluster_id_fields
+        + cluster_misc_fields
+        + primary_positions_fields
+        + strax.time_fields
+    )
 
     # Config options
     # Define the TPC volume
@@ -122,32 +114,19 @@ class XENONnT_BelowCathode(VolumePlugin):
     to ``False``.
     """
 
+    __version__ = "0.3.2"
     depends_on = "clustered_interactions"
-
     provides = "below_cathode_interactions"
     data_kind = "below_cathode_interactions"
-    __version__ = "0.3.1"
 
     # Can we import this from MergeCluster and just add the needed fields?
-    dtype = [
-        (("x position of the cluster [cm]", "x"), np.float32),
-        (("y position of the cluster [cm]", "y"), np.float32),
-        (("z position of the cluster [cm]", "z"), np.float32),
-        (("Energy of the cluster [keV]", "ed"), np.float32),
-        (("NEST interaction type", "nestid"), np.int8),
-        (("Mass number of the interacting particle", "A"), np.int8),
-        (("Charge number of the interacting particle", "Z"), np.int8),
-        (("Geant4 event ID", "evtid"), np.int32),
-        (("x position of the primary particle [cm]", "x_pri"), np.float32),
-        (("y position of the primary particle [cm]", "y_pri"), np.float32),
-        (("z position of the primary particle [cm]", "z_pri"), np.float32),
-        (("ID of the cluster", "cluster_id"), np.int32),
-        (("Xenon density at the cluster position", "xe_density"), np.float32),
-        (("ID of the volume in which the cluster occured", "vol_id"), np.int8),
-        (("Flag indicating if a cluster can create a S2 signal", "create_S2"), np.bool_),
-    ]
-
-    dtype = dtype + strax.time_fields
+    dtype = (
+        cluster_positions_fields
+        + cluster_id_fields
+        + cluster_misc_fields
+        + primary_positions_fields
+        + strax.time_fields
+    )
 
     # Config options
     # Define the volume
@@ -205,32 +184,19 @@ class XENONnT_GasPhase(VolumePlugin):
     meant to go into a vertical merger plugin.
     """
 
+    __version__ = "0.3.2"
     depends_on = "clustered_interactions"
-
     provides = "gas_phase_interactions"
     data_kind = "gas_phase_interactions"
-    __version__ = "0.3.1"
 
     # Can we import this from MergeCluster and just add the needed fields?
-    dtype = [
-        (("x position of the cluster [cm]", "x"), np.float32),
-        (("y position of the cluster [cm]", "y"), np.float32),
-        (("z position of the cluster [cm]", "z"), np.float32),
-        (("Energy of the cluster [keV]", "ed"), np.float32),
-        (("NEST interaction type", "nestid"), np.int8),
-        (("Mass number of the interacting particle", "A"), np.int8),
-        (("Charge number of the interacting particle", "Z"), np.int8),
-        (("Geant4 event ID", "evtid"), np.int32),
-        (("x position of the primary particle [cm]", "x_pri"), np.float32),
-        (("y position of the primary particle [cm]", "y_pri"), np.float32),
-        (("z position of the primary particle [cm]", "z_pri"), np.float32),
-        (("ID of the cluster", "cluster_id"), np.int32),
-        (("Xenon density at the cluster position", "xe_density"), np.float32),
-        (("ID of the volume in which the cluster occured", "vol_id"), np.int8),
-        (("Flag indicating if a cluster can create a S2 signal", "create_S2"), np.bool_),
-    ]
-
-    dtype = dtype + strax.time_fields
+    dtype = (
+        cluster_positions_fields
+        + cluster_id_fields
+        + cluster_misc_fields
+        + primary_positions_fields
+        + strax.time_fields
+    )
 
     # Config options
     # Define the volume

--- a/fuse/plugins/micro_physics/detector_volumes.py
+++ b/fuse/plugins/micro_physics/detector_volumes.py
@@ -47,7 +47,6 @@ class XENONnT_TPC(VolumePlugin):
     provides = "tpc_interactions"
     data_kind = "tpc_interactions"
 
-    # Can we import this from MergeCluster and just add the needed fields?
     dtype = (
         cluster_positions_fields
         + cluster_id_fields
@@ -119,7 +118,6 @@ class XENONnT_BelowCathode(VolumePlugin):
     provides = "below_cathode_interactions"
     data_kind = "below_cathode_interactions"
 
-    # Can we import this from MergeCluster and just add the needed fields?
     dtype = (
         cluster_positions_fields
         + cluster_id_fields
@@ -189,7 +187,6 @@ class XENONnT_GasPhase(VolumePlugin):
     provides = "gas_phase_interactions"
     data_kind = "gas_phase_interactions"
 
-    # Can we import this from MergeCluster and just add the needed fields?
     dtype = (
         cluster_positions_fields
         + cluster_id_fields

--- a/fuse/plugins/micro_physics/electric_field.py
+++ b/fuse/plugins/micro_physics/electric_field.py
@@ -3,6 +3,7 @@ import numpy as np
 import logging
 import straxen
 
+from ...dtypes import electric_fields
 from ...plugin import FuseBasePlugin
 
 export, __all__ = strax.exporter()
@@ -24,10 +25,7 @@ class ElectricField(FuseBasePlugin):
 
     save_when = strax.SaveWhen.TARGET
 
-    dtype = [
-        (("Electric field value at the cluster position [V/cm]", "e_field"), np.float32),
-        *strax.time_fields,
-    ]
+    dtype = electric_fields + strax.time_fields
 
     # Config options
     efield_map = straxen.URLConfig(

--- a/fuse/plugins/micro_physics/find_cluster.py
+++ b/fuse/plugins/micro_physics/find_cluster.py
@@ -33,8 +33,7 @@ class FindCluster(FuseBasePlugin):
 
     dtype = [
         (("Cluster index of the energy deposit", "cluster_ids"), np.int32),
-    ]
-    dtype = dtype + strax.time_fields
+    ] + strax.time_fields
 
     save_when = strax.SaveWhen.TARGET
 

--- a/fuse/plugins/micro_physics/input.py
+++ b/fuse/plugins/micro_physics/input.py
@@ -33,8 +33,6 @@ class ChunkInput(FuseBasePlugin):
     depends_on: Tuple = tuple()
     provides = "geant4_interactions"
 
-    source_done = False
-
     dtype = deposit_positions_fields + g4_fields + primary_positions_fields + strax.time_fields
 
     save_when = strax.SaveWhen.TARGET

--- a/fuse/plugins/micro_physics/input.py
+++ b/fuse/plugins/micro_physics/input.py
@@ -489,9 +489,11 @@ class file_loader:
         df["r"] = np.sqrt(df["x"] ** 2 + df["y"] ** 2)
         df["t"] = df["time"]
 
+        missing_columns = set(self.columns) - set(df.columns)
+
         # Check if all needed columns are in place:
-        if not set(self.columns).issubset(df.columns):
-            log.warning("Not all needed columns provided!")
+        if missing_columns:
+            raise ValueError(f"Not all needed columns provided! {missing_columns} are missing.")
 
         n_simulated_events = len(np.unique(df.eventid))
 

--- a/fuse/plugins/micro_physics/input.py
+++ b/fuse/plugins/micro_physics/input.py
@@ -193,8 +193,8 @@ class file_loader:
 
         self.dtype = deposit_positions_fields + g4_fields
         self.columns = list(np.dtype(self.dtype).names)
-        # Remove evtid as it is not in the usual root or csv file
-        self.columns.remove("evtid")
+        # Remove eventid as it is not in the usual root or csv file
+        self.columns.remove("eventid")
         self.dtype += primary_positions_fields + strax.time_fields
 
         # Prepare cut for root and csv case
@@ -251,7 +251,7 @@ class file_loader:
             ).astype(np.int64)
             event_times = np.sort(event_times)
 
-            structure = np.unique(inter_reshaped["evtid"], return_counts=True)[1]
+            structure = np.unique(inter_reshaped["eventid"], return_counts=True)[1]
 
             # Check again why [:len(structure)] is needed
             interaction_time = np.repeat(event_times[: len(structure)], structure)
@@ -419,7 +419,7 @@ class file_loader:
         )
         eventids = ttree.arrays("eventid", entry_start=start_index, entry_stop=stop_index)
         eventids = ak.broadcast_arrays(eventids["eventid"], interactions["x"])[0]
-        interactions["evtid"] = eventids
+        interactions["eventid"] = eventids
 
         xyz_pri = ttree.arrays(
             ["x_pri", "y_pri", "z_pri"],
@@ -538,7 +538,7 @@ class file_loader:
             "parentid": reshape_awkward(df["parentid"].values, evt_offsets),
             "creaproc": reshape_awkward(np.array(df["creaproc"], dtype=str), evt_offsets),
             "edproc": reshape_awkward(np.array(df["edproc"], dtype=str), evt_offsets),
-            "evtid": reshape_awkward(df["eventid"].values, evt_offsets),
+            "eventid": reshape_awkward(df["eventid"].values, evt_offsets),
         }
 
         return ak.Array(dictionary)

--- a/fuse/plugins/micro_physics/input.py
+++ b/fuse/plugins/micro_physics/input.py
@@ -173,6 +173,7 @@ class file_loader:
     ):
         self.directory = directory
         self.file_name = file_name
+        self.file_type = self.file_name.split(".")[-1]
         self.rng = random_number_generator
         self.separation_scale = separation_scale
         self.event_rate = event_rate / 1e9  # Conversion to ns
@@ -209,9 +210,9 @@ class file_loader:
     def output_chunk(self):
         """Function to return one chunk of data from the root or csv file."""
 
-        if self.file.endswith(".root"):
+        if self.file_type == "root":
             interactions, n_simulated_events, start, stop = self._load_root_file()
-        elif self.file.endswith(".csv"):
+        elif self.file_type == "csv":
             interactions, n_simulated_events, start, stop = self._load_csv_file()
         else:
             raise ValueError(
@@ -257,7 +258,7 @@ class file_loader:
             inter_reshaped["time"] = interaction_time + inter_reshaped["t"]
         elif self.event_rate == 0:
             log.info("Using event times from provided input file.")
-            if self.file.endswith(".root"):
+            if self.file_type == "root":
                 msg = (
                     "Using event times from root file is not recommended! "
                     "Use a source_rate > 0 instead."

--- a/fuse/plugins/micro_physics/input.py
+++ b/fuse/plugins/micro_physics/input.py
@@ -27,7 +27,7 @@ class ChunkInput(FuseBasePlugin):
     and will create multiple chunks of data if needed.
     """
 
-    __version__ = "0.3.2"
+    __version__ = "0.3.3"
 
     depends_on: Tuple = tuple()
     provides = "geant4_interactions"
@@ -35,11 +35,11 @@ class ChunkInput(FuseBasePlugin):
     source_done = False
 
     dtype = [
-        (("x position of the energy deposit [cm]", "x"), np.float64),
-        (("y position of the energy deposit [cm]", "y"), np.float64),
-        (("z position of the energy deposit [cm]", "z"), np.float64),
+        (("x position of the energy deposit [cm]", "x"), np.float32),
+        (("y position of the energy deposit [cm]", "y"), np.float32),
+        (("z position of the energy deposit [cm]", "z"), np.float32),
         (("Time with respect to the start of the event [ns]", "t"), np.float64),
-        (("Energy deposit in keV", "ed"), np.float32),
+        (("Energy deposit [keV]", "ed"), np.float32),
         (("Particle type", "type"), "<U18"),
         (("Geant4 track ID", "trackid"), np.int16),
         (("Particle type of the parent particle", "parenttype"), "<U18"),
@@ -234,11 +234,11 @@ class file_loader:
             self.cut_string = None
 
         self.dtype = [
-            (("x position of the energy deposit [cm]", "x"), np.float64),
-            (("y position of the energy deposit [cm]", "y"), np.float64),
-            (("z position of the energy deposit [cm]", "z"), np.float64),
+            (("x position of the energy deposit [cm]", "x"), np.float32),
+            (("y position of the energy deposit [cm]", "y"), np.float32),
+            (("z position of the energy deposit [cm]", "z"), np.float32),
             (("Time with respect to the start of the event [ns]", "t"), np.float64),
-            (("Energy deposit in keV", "ed"), np.float32),
+            (("Energy deposit [keV]", "ed"), np.float32),
             (("Particle type", "type"), "<U18"),
             (("Geant4 track ID", "trackid"), np.int16),
             (("Particle type of the parent particle", "parenttype"), "<U18"),
@@ -246,9 +246,9 @@ class file_loader:
             (("Geant4 process creating the particle", "creaproc"), "<U25"),
             (("Geant4 process responsible for the energy deposit", "edproc"), "<U25"),
             (("Geant4 event ID", "evtid"), np.int32),
-            (("x position of the primary particle", "x_pri"), np.float32),
-            (("y position of the primary particle", "y_pri"), np.float32),
-            (("z position of the primary particle", "z_pri"), np.float32),
+            (("x position of the primary particle [cm]", "x_pri"), np.float32),
+            (("y position of the primary particle [cm]", "y_pri"), np.float32),
+            (("z position of the primary particle [cm]", "z_pri"), np.float32),
         ]
 
         self.dtype = self.dtype + strax.time_fields

--- a/fuse/plugins/micro_physics/input.py
+++ b/fuse/plugins/micro_physics/input.py
@@ -9,6 +9,7 @@ import pandas as pd
 import strax
 import straxen
 
+from ...dtypes import g4_fields, primary_positions_fields, deposit_positions_fields
 from ...common import full_array_to_numpy, reshape_awkward, dynamic_chunking
 from ...plugin import FuseBasePlugin
 
@@ -34,25 +35,7 @@ class ChunkInput(FuseBasePlugin):
 
     source_done = False
 
-    dtype = [
-        (("x position of the energy deposit [cm]", "x"), np.float32),
-        (("y position of the energy deposit [cm]", "y"), np.float32),
-        (("z position of the energy deposit [cm]", "z"), np.float32),
-        (("Time with respect to the start of the event [ns]", "t"), np.float64),
-        (("Energy deposit [keV]", "ed"), np.float32),
-        (("Particle type", "type"), "<U18"),
-        (("Geant4 track ID", "trackid"), np.int16),
-        (("Particle type of the parent particle", "parenttype"), "<U18"),
-        (("Trackid of the parent particle", "parentid"), np.int16),
-        (("Geant4 process creating the particle", "creaproc"), "<U25"),
-        (("Geant4 process responsible for the energy deposit", "edproc"), "<U25"),
-        (("Geant4 event ID", "evtid"), np.int32),
-        (("x position of the primary particle [cm]", "x_pri"), np.float32),
-        (("y position of the primary particle [cm]", "y_pri"), np.float32),
-        (("z position of the primary particle [cm]", "z_pri"), np.float32),
-    ]
-
-    dtype = dtype + strax.time_fields
+    dtype = deposit_positions_fields + g4_fields + primary_positions_fields + strax.time_fields
 
     save_when = strax.SaveWhen.TARGET
 
@@ -233,23 +216,7 @@ class file_loader:
         else:
             self.cut_string = None
 
-        self.dtype = [
-            (("x position of the energy deposit [cm]", "x"), np.float32),
-            (("y position of the energy deposit [cm]", "y"), np.float32),
-            (("z position of the energy deposit [cm]", "z"), np.float32),
-            (("Time with respect to the start of the event [ns]", "t"), np.float64),
-            (("Energy deposit [keV]", "ed"), np.float32),
-            (("Particle type", "type"), "<U18"),
-            (("Geant4 track ID", "trackid"), np.int16),
-            (("Particle type of the parent particle", "parenttype"), "<U18"),
-            (("Trackid of the parent particle", "parentid"), np.int16),
-            (("Geant4 process creating the particle", "creaproc"), "<U25"),
-            (("Geant4 process responsible for the energy deposit", "edproc"), "<U25"),
-            (("Geant4 event ID", "evtid"), np.int32),
-            (("x position of the primary particle [cm]", "x_pri"), np.float32),
-            (("y position of the primary particle [cm]", "y_pri"), np.float32),
-            (("z position of the primary particle [cm]", "z_pri"), np.float32),
-        ]
+        self.dtype = deposit_positions_fields + g4_fields + primary_positions_fields
 
         self.dtype = self.dtype + strax.time_fields
 

--- a/fuse/plugins/micro_physics/merge_cluster.py
+++ b/fuse/plugins/micro_physics/merge_cluster.py
@@ -100,7 +100,7 @@ def cluster_and_classify(result, interactions, tag_cluster_by):
         result[i]["x_pri"] = cluster["x_pri"][main_interaction_index]
         result[i]["y_pri"] = cluster["y_pri"][main_interaction_index]
         result[i]["z_pri"] = cluster["z_pri"][main_interaction_index]
-        result[i]["evtid"] = cluster["evtid"][main_interaction_index]
+        result[i]["eventid"] = cluster["eventid"][main_interaction_index]
 
         # Get cluster id from and save it!
         result[i]["cluster_id"] = cluster["cluster_ids"][main_interaction_index]

--- a/fuse/plugins/micro_physics/merge_cluster.py
+++ b/fuse/plugins/micro_physics/merge_cluster.py
@@ -3,6 +3,12 @@ import straxen
 import numpy as np
 import logging
 
+from ...dtypes import (
+    primary_positions_fields,
+    cluster_positions_fields,
+    cluster_id_fields,
+    cluster_misc_fields,
+)
 from ...plugin import FuseBasePlugin
 
 export, __all__ = strax.exporter()
@@ -25,40 +31,20 @@ class MergeCluster(FuseBasePlugin):
     interaction.
     """
 
-    __version__ = "0.3.1"
-
+    __version__ = "0.3.2"
     depends_on = ("geant4_interactions", "cluster_index")
-
     provides = "clustered_interactions"
     data_kind = "clustered_interactions"
 
     save_when = strax.SaveWhen.TARGET
 
-    dtype = [
-        (("x position of the cluster [cm]", "x"), np.float32),
-        (("y position of the cluster [cm]", "y"), np.float32),
-        (("z position of the cluster [cm]", "z"), np.float32),
-        (("Energy of the cluster [keV]", "ed"), np.float32),
-        (("NEST interaction type", "nestid"), np.int8),
-        (("Mass number of the interacting particle", "A"), np.int8),
-        (("Charge number of the interacting particle", "Z"), np.int8),
-        (("Geant4 event ID", "evtid"), np.int32),
-        (("x position of the primary particle [cm]", "x_pri"), np.float32),
-        (("y position of the primary particle [cm]", "y_pri"), np.float32),
-        (("z position of the primary particle [cm]", "z_pri"), np.float32),
-        (("ID of the cluster", "cluster_id"), np.int32),
-        (("Xenon density at the cluster position. Will be set later", "xe_density"), np.float32),
-        (("ID of the volume in which the cluster occured. Will be set later", "vol_id"), np.int8),
-        (
-            (
-                "Flag indicating if a cluster can create a S2 signal. Will be set later",
-                "create_S2",
-            ),
-            np.bool_,
-        ),
-    ]
-
-    dtype = dtype + strax.time_fields
+    dtype = (
+        cluster_positions_fields
+        + cluster_id_fields
+        + cluster_misc_fields
+        + primary_positions_fields
+        + strax.time_fields
+    )
 
     # Config options
     tag_cluster_by = straxen.URLConfig(

--- a/fuse/plugins/micro_physics/wfsim_connection.py
+++ b/fuse/plugins/micro_physics/wfsim_connection.py
@@ -72,10 +72,10 @@ class output_plugin(FuseBasePlugin):
         # TODO: Currently not supported rows with only electrons or photons due to
         # this super odd shape
         for i in range(2):
-            structure = np.unique(interactions["evtid"], return_counts=True)[1]
-            evtid = reshape_awkward(interactions["evtid"], structure)
+            structure = np.unique(interactions["eventid"], return_counts=True)[1]
+            eventid = reshape_awkward(interactions["eventid"], structure)
 
-            res["event_number"][i::2] = offset_range(ak.to_numpy(ak.num(evtid)))
+            res["event_number"][i::2] = offset_range(ak.to_numpy(ak.num(eventid)))
             res["type"][i::2] = i + 1
             res["x"][i::2] = interactions["x"]
             res["y"][i::2] = interactions["y"]
@@ -83,7 +83,7 @@ class output_plugin(FuseBasePlugin):
             res["x_pri"][i::2] = interactions["x_pri"]
             res["y_pri"][i::2] = interactions["y_pri"]
             res["z_pri"][i::2] = interactions["z_pri"]
-            res["g4id"][i::2] = interactions["evtid"]
+            res["g4id"][i::2] = interactions["eventid"]
             res["vol_id"][i::2] = interactions["vol_id"]
             res["e_dep"][i::2] = interactions["ed"]
             if "local_field" in res.dtype.names:

--- a/fuse/plugins/micro_physics/wfsim_connection.py
+++ b/fuse/plugins/micro_physics/wfsim_connection.py
@@ -7,7 +7,6 @@ import awkward as ak
 import numpy as np
 import strax
 
-from ...dtypes import primary_positions_fields
 from ...common import offset_range, reshape_awkward
 from ...plugin import FuseBasePlugin
 
@@ -43,7 +42,10 @@ class output_plugin(FuseBasePlugin):
         (("Volume id giving the detector subvolume", "vol_id"), np.int32),
         (("Local field [ V / cm ]", "local_field"), np.float64),
         (("Number of excitons", "n_excitons"), np.int32),
-    ] + primary_positions_fields
+        (("X position of the primary particle [cm]", "x_pri"), np.float32),
+        (("Y position of the primary particle [cm]", "y_pri"), np.float32),
+        (("Z position of the primary particle [cm]", "z_pri"), np.float32),
+    ]
 
     def compute(self, interactions_in_roi):
         if len(interactions_in_roi) == 0:

--- a/fuse/plugins/micro_physics/wfsim_connection.py
+++ b/fuse/plugins/micro_physics/wfsim_connection.py
@@ -7,6 +7,7 @@ import awkward as ak
 import numpy as np
 import strax
 
+from ...dtypes import primary_positions_fields
 from ...common import offset_range, reshape_awkward
 from ...plugin import FuseBasePlugin
 
@@ -42,10 +43,7 @@ class output_plugin(FuseBasePlugin):
         (("Volume id giving the detector subvolume", "vol_id"), np.int32),
         (("Local field [ V / cm ]", "local_field"), np.float64),
         (("Number of excitons", "n_excitons"), np.int32),
-        (("X position of the primary particle [cm]", "x_pri"), np.float32),
-        (("Y position of the primary particle [cm]", "y_pri"), np.float32),
-        (("Z position of the primary particle [cm]", "z_pri"), np.float32),
-    ]
+    ] + primary_positions_fields
 
     def compute(self, interactions_in_roi):
         if len(interactions_in_roi) == 0:

--- a/fuse/plugins/micro_physics/yields.py
+++ b/fuse/plugins/micro_physics/yields.py
@@ -5,6 +5,7 @@ import straxen
 import logging
 import pickle
 
+from ...dtypes import quanta_fields
 from ...plugin import FuseBasePlugin
 
 export, __all__ = strax.exporter()
@@ -28,13 +29,7 @@ class NestYields(FuseBasePlugin):
     provides = "quanta"
     data_kind = "interactions_in_roi"
 
-    dtype = [
-        (("Number of photons at interaction position", "photons"), np.int32),
-        (("Number of electrons at interaction position", "electrons"), np.int32),
-        (("Number of excitons at interaction position", "excitons"), np.int32),
-    ]
-
-    dtype = dtype + strax.time_fields
+    dtype = quanta_fields + strax.time_fields
 
     save_when = strax.SaveWhen.TARGET
 
@@ -178,9 +173,7 @@ class BetaYields(strax.Plugin):
         ("photons", np.int32),
         ("electrons", np.int32),
         ("excitons", np.int32),
-    ]
-
-    dtype = dtype + strax.time_fields
+    ] + strax.time_fields
 
     # Forbid rechunking
     rechunk_on_save = False
@@ -311,13 +304,7 @@ class BBFYields(FuseBasePlugin):
     depends_on = ("interactions_in_roi", "electric_field_values")
     provides = "quanta"
 
-    dtype = [
-        ("photons", np.int32),
-        ("electrons", np.int32),
-        ("excitons", np.int32),
-    ]
-
-    dtype = dtype + strax.time_fields
+    dtype = quanta_fields + strax.time_fields
 
     def setup(self):
         super().setup()

--- a/fuse/plugins/pmt_and_daq/pmt_afterpulses.py
+++ b/fuse/plugins/pmt_and_daq/pmt_afterpulses.py
@@ -3,6 +3,7 @@ import numpy as np
 import straxen
 import logging
 
+from ...dtypes import propagated_photons_fields
 from ...common import pmt_gains
 from ...plugin import FuseBasePlugin
 
@@ -30,13 +31,7 @@ class PMTAfterPulses(FuseBasePlugin):
 
     save_when = strax.SaveWhen.TARGET
 
-    dtype = [
-        (("PMT channel of the photon", "channel"), np.int16),
-        (("Photon creates a double photo-electron emission", "dpe"), np.bool_),
-        (("Sampled PMT gain for the photon", "photon_gain"), np.int32),
-        (("ID of the cluster creating the photon", "cluster_id"), np.int32),
-        (("Type of the photon. S1 (1), S2 (2) or PMT AP (0)", "photon_type"), np.int8),
-    ] + strax.time_fields
+    dtype = propagated_photons_fields + strax.time_fields
 
     # Config options
 

--- a/fuse/plugins/pmt_and_daq/pmt_afterpulses.py
+++ b/fuse/plugins/pmt_and_daq/pmt_afterpulses.py
@@ -36,8 +36,7 @@ class PMTAfterPulses(FuseBasePlugin):
         (("Sampled PMT gain for the photon", "photon_gain"), np.int32),
         (("ID of the cluster creating the photon", "cluster_id"), np.int32),
         (("Type of the photon. S1 (1), S2 (2) or PMT AP (0)", "photon_type"), np.int8),
-    ]
-    dtype = dtype + strax.time_fields
+    ] + strax.time_fields
 
     # Config options
 

--- a/fuse/plugins/truth_information/cluster_tagging.py
+++ b/fuse/plugins/truth_information/cluster_tagging.py
@@ -24,8 +24,7 @@ class ClusterTagging(strax.Plugin):
         ("photons_in_main_s2", np.int32),
         ("photons_in_alt_s1", np.int32),
         ("photons_in_alt_s2", np.int32),
-    ]
-    dtype = dtype + strax.time_fields
+    ] + strax.time_fields
 
     def compute(self, interactions_in_roi, propagated_photons, peaks, events):
         peaks_in_event = strax.split_by_containment(peaks, events)

--- a/fuse/plugins/truth_information/event_truth.py
+++ b/fuse/plugins/truth_information/event_truth.py
@@ -18,8 +18,7 @@ class EventTruth(strax.Plugin):
         ("z_obs_truth", np.float32),
         ("energy_of_main_peaks_truth", np.float32),
         ("total_energy_in_event_truth", np.float32),
-    ]
-    dtype = dtype + strax.time_fields
+    ] + strax.time_fields
 
     def compute(self, interactions_in_roi, propagated_photons, peaks, events):
         peaks_in_event = strax.split_by_containment(peaks, events)

--- a/fuse/plugins/truth_information/peak_truth.py
+++ b/fuse/plugins/truth_information/peak_truth.py
@@ -38,8 +38,7 @@ class PeakTruth(strax.OverlapWindowPlugin):
         ("average_x_obs_of_contributing_clusters", np.float32),
         ("average_y_obs_of_contributing_clusters", np.float32),
         ("average_z_obs_of_contributing_clusters", np.float32),
-    ]
-    dtype = dtype + strax.time_fields
+    ] + strax.time_fields
 
     gain_model_mc = straxen.URLConfig(
         default="cmt://to_pe_model?version=ONLINE&run_id=plugin.run_id",

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -42,7 +42,7 @@ class TestInput(unittest.TestCase):
             }
         )
         g4_loaded = test_context.get_array(self.run_number, "geant4_interactions")
-        loaded_event_count = len(np.unique(g4_loaded["evtid"]))
+        loaded_event_count = len(np.unique(g4_loaded["eventid"]))
         self.assertTrue(
             loaded_event_count == 52, f"Expecting 52 events, but got {loaded_event_count} events"
         )
@@ -59,7 +59,7 @@ class TestInput(unittest.TestCase):
             }
         )
         g4_loaded = test_context.get_array(self.run_number, "geant4_interactions")
-        loaded_event_count = len(np.unique(g4_loaded["evtid"]))
+        loaded_event_count = len(np.unique(g4_loaded["eventid"]))
 
         self.assertTrue(
             loaded_event_count == 26, f"Expecting 26 events, but got {loaded_event_count} events"
@@ -72,7 +72,7 @@ class TestInput(unittest.TestCase):
             {"path": self.temp_dir.name, "file_name": test_root_file_name, "cut_by_eventid": True}
         )
         g4_loaded = test_context.get_array(self.run_number, "geant4_interactions")
-        loaded_event_count = len(np.unique(g4_loaded["evtid"]))
+        loaded_event_count = len(np.unique(g4_loaded["eventid"]))
         self.assertTrue(
             loaded_event_count == 52, f"Expecting 52 events, but got {loaded_event_count} events"
         )
@@ -90,7 +90,7 @@ class TestInput(unittest.TestCase):
             }
         )
         g4_loaded = test_context.get_array(self.run_number, "geant4_interactions")
-        loaded_event_count = len(np.unique(g4_loaded["evtid"]))
+        loaded_event_count = len(np.unique(g4_loaded["eventid"]))
         self.assertTrue(
             loaded_event_count == 23, f"Expecting 23 events, but got {loaded_event_count} events"
         )


### PR DESCRIPTION
Similar to https://github.com/XENONnT/fuse/pull/147, but I added a type manager for all plugins.

1. please look at `fuse/dtypes.py` for all lists of fields
2. remove `". Will be set later"` from dtype of `clustered_interactions`
3. add `csv_input_fields` indicating the needed fields for `ChunkCsvInput`

This PR will also remove the trouble of updating the same field distributed in different files later.