### PR TITLE
No photons from electrons outside

### DIFF
--- a/fuse/common.py
+++ b/fuse/common.py
@@ -308,7 +308,6 @@ def build_photon_propagation_output(
 
     # Remove photons with photon_gain <= 0
     result = result[result["photon_gain"] > 0]
-    result = result[result["channel"] >= 0]
 
     return result
 

--- a/fuse/common.py
+++ b/fuse/common.py
@@ -308,6 +308,7 @@ def build_photon_propagation_output(
 
     # Remove photons with photon_gain <= 0
     result = result[result["photon_gain"] > 0]
+    result = result[result["channel"] >= 0]
 
     return result
 

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -467,6 +467,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
                 pat[bottom_index] *= (1 - _new_aft) / (1 - _cur_aft)
 
             # Pattern map return zeros
+            # Photons will be rejected when building photon propagation output
             if np.isnan(pat).sum() > 0:
                 _photon_channels = np.array([-1] * n_ph)
 

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -33,7 +33,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
     Note: The timing calculation is defined in the child plugin.
     """
 
-    __version__ = "0.3.3"
+    __version__ = "0.3.4"
 
     depends_on = (
         "merged_electron_time",

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -470,7 +470,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
                 pat[bottom_index] *= (1 - _new_aft) / (1 - _cur_aft)
 
             # If pattern map return zeros or has NAN values assign negative channel
-            # Photons with negative channel number will be rejected when 
+            # Photons with negative channel number will be rejected when
             # building photon propagation output
             if np.isnan(pat).sum() > 0:
                 _photon_channels = np.array([-1] * n_ph)

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -424,6 +424,9 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
             photon_type=2,
         )
 
+        # Discard photons associated with negative channel numbers
+        result = result[result["channel"] >= 0]
+
         result = strax.sort_by_time(result)
 
         return result
@@ -466,8 +469,8 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
                 pat[top_index] *= _new_aft / _cur_aft
                 pat[bottom_index] *= (1 - _new_aft) / (1 - _cur_aft)
 
-            # Pattern map return zeros
-            # Photons will be rejected when building photon propagation output
+            # If pattern map return zeros or has NAN values assign negative channel
+            # Photons with negative channel number will be rejected when building photon propagation output
             if np.isnan(pat).sum() > 0:
                 _photon_channels = np.array([-1] * n_ph)
 

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -470,7 +470,8 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
                 pat[bottom_index] *= (1 - _new_aft) / (1 - _cur_aft)
 
             # If pattern map return zeros or has NAN values assign negative channel
-            # Photons with negative channel number will be rejected when building photon propagation output
+            # Photons with negative channel number will be rejected when 
+            # building photon propagation output
             if np.isnan(pat).sum() > 0:
                 _photon_channels = np.array([-1] * n_ph)
 


### PR DESCRIPTION
Do not return photons if all PMTs have no probability of being hit or if all electrons in a cluster are outside the TPC. In these cases, channel number is assigned negative. Only take photons with positive channel number

_Before you submit this PR: make sure to put all XENONnT specific information in a wiki-note as the repo is publicly accessible_

## What does the code in this PR do / what does it improve?
Solves the Issue #199 
## Can you briefly describe how it works?
If there are no electrons extracted within the TPC, when calculating the average position of all electrons in the cluster of extracted electrons (in this case 0), the PMT patter probability distribution is filled with not-a-number values. If this is the case, for each photon that was calculated to be emitted by the extracted electrons, the channel number is set to be -1.

If this PR is accepted, at the end of the plugin, when values are returned, all photons with negative channel numbers are rejected.
## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [x] _Bump plugin version(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [x] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
