### PR TITLE
Add x_truth, y_truth, z_truth

### DIFF
--- a/fuse/plugins/truth_information/event_truth.py
+++ b/fuse/plugins/truth_information/event_truth.py
@@ -6,7 +6,7 @@ export, __all__ = strax.exporter()
 
 @export
 class EventTruth(strax.Plugin):
-    __version__ = "0.0.3"
+    __version__ = "0.0.4"
 
     depends_on = ("microphysics_summary", "photon_summary", "peak_truth", "event_basics")
     provides = "event_truth"

--- a/fuse/plugins/truth_information/event_truth.py
+++ b/fuse/plugins/truth_information/event_truth.py
@@ -13,6 +13,9 @@ class EventTruth(strax.Plugin):
     data_kind = "events"
 
     dtype = [
+        ("x_truth", np.float32),
+        ("y_truth", np.float32),
+        ("z_truth", np.float32),
         ("x_obs_truth", np.float32),
         ("y_obs_truth", np.float32),
         ("z_obs_truth", np.float32),
@@ -33,6 +36,15 @@ class EventTruth(strax.Plugin):
         for i, (pic, e) in enumerate(zip(peaks_in_event, events)):
             s1 = pic[e["s1_index"]]
             s2 = pic[e["s2_index"]]
+
+            result["x_truth"][i] = s2["average_x_of_contributing_clusters"]
+            result["y_truth"][i] = s2["average_y_of_contributing_clusters"]
+            result["z_truth"][i] = np.mean(
+                [
+                    s2["average_z_of_contributing_clusters"],
+                    s1["average_z_of_contributing_clusters"],
+                ]
+            )
 
             result["x_obs_truth"][i] = s2["average_x_obs_of_contributing_clusters"]
             result["y_obs_truth"][i] = s2["average_y_obs_of_contributing_clusters"]


### PR DESCRIPTION
_Before you submit this PR: make sure to put all XENONnT specific information in a wiki-note as the repo is publicly accessible_

## What does the code in this PR do / what does it improve?
The plugin now returns x, y, and z truth values defined. The difference between these and the `_obs_truth` values is the same as the difference between `average_<coord>_of_contributing_clusters` and `average_<coord>_obs_of_contributing_clusters` from peak_truth plugin.

## Can you briefly describe how it works?
The few lines this PR adds to the `event_truth` plugin simply add  `average_x_of_contributing_clusters` and  `average_y_of_contributing_clusters` of the main S2 peak of the current event as the `x_truth` and `y_truth` values in the result.
Furthermore, it adds the mean of the  `average_z_of_contributing_clusters` of the main S1 and S2 peaks of the event as `z_truth`, by following the same logic used to define `z_obs_truth`.

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [x] _Bump plugin version(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
