### PR TITLE
Rename s1 photon hits output

### DIFF
--- a/examples/2_Detectorphysics_Simulation.ipynb
+++ b/examples/2_Detectorphysics_Simulation.ipynb
@@ -80,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "st.make(run_number, \"s1_photons\")\n",
+    "st.make(run_number, \"s1_photon_hits\")\n",
     "st.make(run_number, \"propagated_s1_photons\")"
    ]
   },
@@ -169,7 +169,7 @@
    "source": [
     "### Combining the Results\n",
     "\n",
-    "Now that we have everything prepared for our S1 and S2 signals we can take a look at how we can combine these simulation results. First we can load `s2_photons_sum` along with `s1_photons`, `drifted_electrons`, `extracted_electrons` and `microphysics_summary`. "
+    "Now that we have everything prepared for our S1 and S2 signals we can take a look at how we can combine these simulation results. First we can load `s2_photons_sum` along with `s1_photon_hits`, `drifted_electrons`, `extracted_electrons` and `microphysics_summary`. "
    ]
   },
   {
@@ -183,7 +183,7 @@
     "    [\n",
     "        \"microphysics_summary\",\n",
     "        \"s2_photons_sum\",\n",
-    "        \"s1_photons\",\n",
+    "        \"s1_photon_hits\",\n",
     "        \"drifted_electrons\",\n",
     "        \"extracted_electrons\",\n",
     "    ],\n",

--- a/fuse/plugins/detector_physics/delayed_electrons/delayed_electrons_merger.py
+++ b/fuse/plugins/detector_physics/delayed_electrons/delayed_electrons_merger.py
@@ -82,8 +82,8 @@ class S1PhotonHitsMerger(VerticalMergerPlugin):
     """Plugin which concatenates the output of the regular and delayed s1
     photon hits plugins."""
 
-    depends_on = ("s1_photons", "delayed_s1_photons")
+    depends_on = ("s1_photon_hits", "delayed_s1_photon_hits")
 
-    provides = "merged_s1_photons"
+    provides = "merged_s1_photon_hits"
     data_kind = "interactions_in_roi"
     __version__ = "0.0.2"

--- a/fuse/plugins/detector_physics/delayed_electrons/delayed_electrons_merger.py
+++ b/fuse/plugins/detector_physics/delayed_electrons/delayed_electrons_merger.py
@@ -86,4 +86,4 @@ class S1PhotonHitsMerger(VerticalMergerPlugin):
 
     provides = "merged_s1_photon_hits"
     data_kind = "interactions_in_roi"
-    __version__ = "0.0.1"
+    __version__ = "0.0.2"

--- a/fuse/plugins/detector_physics/delayed_electrons/delayed_electrons_s1photonhits.py
+++ b/fuse/plugins/detector_physics/delayed_electrons/delayed_electrons_s1photonhits.py
@@ -14,7 +14,7 @@ log = logging.getLogger("fuse.detector_physics.delayed_electrons.delayed_electro
 class S1PhotonHitsEmpty(FuseBasePlugin):
     """Plugin to return zeros for all S1 photon hits of delayed electrons."""
 
-    __version__ = "0.0.1"
+    __version__ = "0.0.2"
 
     depends_on = "photo_ionization_electrons"
     provides = "delayed_s1_photon_hits"

--- a/fuse/plugins/detector_physics/delayed_electrons/delayed_electrons_s1photonhits.py
+++ b/fuse/plugins/detector_physics/delayed_electrons/delayed_electrons_s1photonhits.py
@@ -17,7 +17,7 @@ class S1PhotonHitsEmpty(FuseBasePlugin):
     __version__ = "0.0.2"
 
     depends_on = "photo_ionization_electrons"
-    provides = "delayed_s1_photons"
+    provides = "delayed_s1_photon_hits"
     data_kind = "delayed_interactions_in_roi"
 
     dtype = [

--- a/fuse/plugins/detector_physics/s1_photon_hits.py
+++ b/fuse/plugins/detector_physics/s1_photon_hits.py
@@ -19,7 +19,7 @@ class S1PhotonHits(FuseBasePlugin):
     """Plugin to simulate the number of detected S1 photons using a S1 light
     collection efficiency map."""
 
-    __version__ = "0.2.0"
+    __version__ = "0.2.1"
 
     depends_on = "microphysics_summary"
     provides = "s1_photon_hits"

--- a/fuse/plugins/detector_physics/s1_photon_hits.py
+++ b/fuse/plugins/detector_physics/s1_photon_hits.py
@@ -22,7 +22,7 @@ class S1PhotonHits(FuseBasePlugin):
     __version__ = "0.2.1"
 
     depends_on = "microphysics_summary"
-    provides = "s1_photons"
+    provides = "s1_photon_hits"
     data_kind = "interactions_in_roi"
 
     save_when = strax.SaveWhen.ALWAYS

--- a/fuse/plugins/detector_physics/s1_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s1_photon_propagation.py
@@ -35,7 +35,7 @@ class S1PhotonPropagationBase(FuseBasePlugin):
 
     __version__ = "0.3.2"
 
-    depends_on = ("microphysics_summary", "s1_photons")
+    depends_on = ("microphysics_summary", "s1_photon_hits")
     provides = "propagated_s1_photons"
     data_kind = "s1_photons"
 

--- a/fuse/plugins/detector_physics/s1_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s1_photon_propagation.py
@@ -33,7 +33,7 @@ class S1PhotonPropagationBase(FuseBasePlugin):
     Note: The timing calculation is defined in the child plugin.
     """
 
-    __version__ = "0.3.1"
+    __version__ = "0.3.2"
 
     depends_on = ("microphysics_summary", "s1_photon_hits")
     provides = "propagated_s1_photons"

--- a/fuse/plugins/truth_information/peak_truth.py
+++ b/fuse/plugins/truth_information/peak_truth.py
@@ -15,7 +15,7 @@ class PeakTruth(strax.OverlapWindowPlugin):
         "photon_summary",
         "peak_basics",
         "merged_microphysics_summary",
-        "merged_s1_photons",
+        "merged_s1_photon_hits",
         "merged_s2_photons_sum",
         "merged_drifted_electrons",
     )

--- a/tests/test_FullChain.py
+++ b/tests/test_FullChain.py
@@ -48,7 +48,7 @@ class TestFullChain(unittest.TestCase):
 
     @timeout_decorator.timeout(TIMEOUT, exception_message="S1PhotonHits timed out")
     def test_S1PhotonHits(self):
-        self.test_context.make(self.run_number, "s1_photons")
+        self.test_context.make(self.run_number, "s1_photon_hits")
 
     @timeout_decorator.timeout(TIMEOUT, exception_message="S1PhotonPropagation timed out")
     def test_S1PhotonPropagation(self):

--- a/tests/test_FullChain_w_DelayedElectrons.py
+++ b/tests/test_FullChain_w_DelayedElectrons.py
@@ -53,7 +53,7 @@ class TestFullChainwDelayedElectrons(unittest.TestCase):
     @timeout_decorator.timeout(TIMEOUT, exception_message="S1PhotonHits timed out")
     def test_S1PhotonHits(self):
 
-        self.test_context.make(self.run_number, "s1_photons")
+        self.test_context.make(self.run_number, "s1_photon_hits")
 
     @timeout_decorator.timeout(TIMEOUT, exception_message="S1PhotonPropagation timed out")
     def test_S1PhotonPropagation(self):
@@ -114,7 +114,7 @@ class TestFullChainwDelayedElectrons(unittest.TestCase):
     )
     def test_DelayedElectronsS1PhotonHitsEmpty(self):
 
-        self.test_context.make(self.run_number, "delayed_s1_photons")
+        self.test_context.make(self.run_number, "delayed_s1_photon_hits")
 
     @timeout_decorator.timeout(TIMEOUT, exception_message="S2PhotonPropagation timed out")
     def test_S2PhotonPropagation(self):


### PR DESCRIPTION
_Before you submit this PR: make sure to put all XENONnT specific information in a wiki-note as the repo is publicly accessible_

## What does the code in this PR do / what does it improve?

This PR renames the output of the `S1PhotonHits` plugin from `"s1_photons"` to `"s1_photon_hits"` to avoid confusion with the dtype of the propagated s1 photons. 

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [x] _Bump plugin version(s)_
  - [x] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [x] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
