### PR TITLE
Change dtype for time input back to float64

### DIFF
--- a/fuse/dtypes.py
+++ b/fuse/dtypes.py
@@ -2,7 +2,7 @@ import numpy as np
 
 
 g4_fields = [
-    (("Time with respect to the start of the event [ns]", "t"), np.int64),
+    (("Time with respect to the start of the event [ns]", "t"), np.float64),
     (("Energy deposit [keV]", "ed"), np.float32),
     (("Particle type", "type"), "<U18"),
     (("Geant4 track ID", "trackid"), np.int16),


### PR DESCRIPTION
_Before you submit this PR: make sure to put all XENONnT specific information in a wiki-note as the repo is publicly accessible_

## What does the code in this PR do / what does it improve?

This PR changes the dtype for Geant4 times back to float64. 

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Bump plugin version(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [x] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
