### PR TITLE
Add tight coincidence and peak tagging in `ClusterTagging`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Test package](https://github.com/XENONnT/fuse/actions/workflows/pytest.yml/badge.svg?branch=main)](https://github.com/XENONnT/fuse/actions/workflows/pytest.yml)
 [![Readthedocs Badge](https://readthedocs.org/projects/fuse/badge/?version=latest)](https://xenon-fuse.readthedocs.io/en/latest/?badge=latest)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/XENONnT/fuse/main.svg)](https://results.pre-commit.ci/latest/github/XENONnT/fuse/main)
+[![DOI](https://zenodo.org/badge/622956443.svg)](https://zenodo.org/doi/10.5281/zenodo.11059395)
 
 **F**ramework for **U**nified **S**imulation of **E**vents
 

--- a/fuse/plugins/truth_information/cluster_tagging.py
+++ b/fuse/plugins/truth_information/cluster_tagging.py
@@ -35,7 +35,7 @@ class ClusterTagging(strax.Plugin):
     photon_finding_window = straxen.URLConfig(
         default=200,
         type=int,
-        help="Time window [ns] that defines whether a photon is in a peak. Peaks' start and end times are extended by this window.",
+        help="Time window [ns] that defines whether a photon is in a peak. Peaks' start and end times are extended by this window to find photons in them.",
     )
 
     def compute(self, interactions_in_roi, propagated_photons, peaks, events):
@@ -59,7 +59,7 @@ class ClusterTagging(strax.Plugin):
         for i, (peaks_of_event, event_i, photon_of_event) in enumerate(
             zip(peaks_in_event, events, photon_in_event)
         ):
-            peak_photons = strax.split_touching_windows(photon_of_event, peaks_of_event)
+            peak_photons = strax.split_touching_windows(photon_of_event, peaks_of_event, window=self.photon_finding_window)
 
             peak_name_dict = {
                 "main_s1": "s1_index",

--- a/fuse/plugins/truth_information/cluster_tagging.py
+++ b/fuse/plugins/truth_information/cluster_tagging.py
@@ -7,8 +7,8 @@ export, __all__ = strax.exporter()
 
 @export
 class ClusterTagging(strax.Plugin):
-    """Plugin to tag if clusters contribute to the main or alternative
-    s1/s2 in an event, or successfully reconstructed as s0/s1/s2 peaks."""
+    """Plugin to tag if clusters contribute to the main or alternative s1/s2 in
+    an event, or successfully reconstructed as s0/s1/s2 peaks."""
 
     __version__ = "0.0.4"
 
@@ -36,7 +36,7 @@ class ClusterTagging(strax.Plugin):
         default=200,
         type=int,
         help="Time window [ns] that defines whether a photon is in a peak. "
-             "Peaks' start and end times are extended by this window to find photons in them.",
+        "Peaks' start and end times are extended by this window to find photons in them.",
     )
 
     def compute(self, interactions_in_roi, propagated_photons, peaks, events):

--- a/fuse/plugins/truth_information/cluster_tagging.py
+++ b/fuse/plugins/truth_information/cluster_tagging.py
@@ -8,7 +8,7 @@ export, __all__ = strax.exporter()
 @export
 class ClusterTagging(strax.Plugin):
     """Plugin to tag if clusters contribute to the main or alternative
-    s1/s2."""
+    s1/s2 in an event, or successfully reconstructed as s0/s1/s2 peaks."""
 
     __version__ = "0.0.4"
 
@@ -35,7 +35,8 @@ class ClusterTagging(strax.Plugin):
     photon_finding_window = straxen.URLConfig(
         default=200,
         type=int,
-        help="Time window [ns] that defines whether a photon is in a peak. Peaks' start and end times are extended by this window to find photons in them.",
+        help="Time window [ns] that defines whether a photon is in a peak. "
+             "Peaks' start and end times are extended by this window to find photons in them.",
     )
 
     def compute(self, interactions_in_roi, propagated_photons, peaks, events):

--- a/fuse/plugins/truth_information/cluster_tagging.py
+++ b/fuse/plugins/truth_information/cluster_tagging.py
@@ -44,13 +44,15 @@ class ClusterTagging(strax.Plugin):
         result["endtime"] = interactions_in_roi["endtime"]
 
         # First we tag the clusters that are in a peak
-        photons_in_peak = strax.split_touching_windows(interactions_in_roi, peaks, window=self.photon_finding_window)
+        photons_in_peak = strax.split_touching_windows(
+            interactions_in_roi, peaks, window=self.photon_finding_window
+        )
         for peak, photons in zip(peaks, photons_in_peak):
-            peak_type = peak['type']
-            mask = np.isin(interactions_in_roi['cluster_id'], photons['cluster_id'])
+            peak_type = peak["type"]
+            mask = np.isin(interactions_in_roi["cluster_id"], photons["cluster_id"])
             result["in_peak"][mask] = True
             result[f"in_s{peak_type}"][mask] = True
-            result["tight_coincidence"][mask] = peak['tight_coincidence']
+            result["tight_coincidence"][mask] = peak["tight_coincidence"]
 
         # Then we tag the clusters that are in an event's main or alternative s1/s2
         peaks_in_event = strax.split_by_containment(peaks, events)
@@ -59,7 +61,9 @@ class ClusterTagging(strax.Plugin):
         for i, (peaks_of_event, event_i, photon_of_event) in enumerate(
             zip(peaks_in_event, events, photon_in_event)
         ):
-            peak_photons = strax.split_touching_windows(photon_of_event, peaks_of_event, window=self.photon_finding_window)
+            peak_photons = strax.split_touching_windows(
+                photon_of_event, peaks_of_event, window=self.photon_finding_window
+            )
 
             peak_name_dict = {
                 "main_s1": "s1_index",


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
This PR adds some fields in `ClusterTagging` plugin based only on peaks. The new fields don't tell you whether the peaks are main/alternative but only S0/S1/S2 and the tight coincidence of the peaks. This definition is consistent with the reconstruction efficiency.

I also added a new parameter `photon_finding_window` as the window of `touching_window_split`. This is because that there are some photons reconstructed as peaks successfully, but the peaks' start and end times are both later than the photon time (i.e. the cluster time) thus it cannot be tagged if we simply use `window=0`. Currently it's set to 200ns, meaning peaks' start and end times are extended both 200ns to find photons.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

  - [x] _Update the docstring(s)_
  - [x] _Bump plugin version(s)_
  - [x] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
