### PR TITLE
Add missing return to stop plugin in case of empty input

### DIFF
--- a/fuse/plugins/pmt_and_daq/pmt_response_and_daq.py
+++ b/fuse/plugins/pmt_and_daq/pmt_response_and_daq.py
@@ -220,6 +220,7 @@ class PMTResponseAndDAQ(FuseBaseDownChunkingPlugin):
             log.debug("No photons or pulse windows found for chunk!")
 
             yield self.chunk(start=start, end=end, data=np.zeros(0, dtype=self.dtype))
+            return  # Exit early
 
         # Split into "sub-chunks"
         pulse_gaps = pulse_windows["time"][1:] - strax.endtime(pulse_windows)[:-1]


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
This PR fixes a problem with empty input chunks to the PMTResponseAndDAQ plugin. Before this fix, the iteration for empty chunks was not properly stoped leading to `data not continuous` problems. 

## Can you briefly describe how it works?
I added the missing `return` to the empty input case of the PMTResponseAndDAQ plugin. 

_Please include the following if applicable:_
  - [ ] _Bump plugin version(s)_
  - [ ] _Tests to check the (new) code is working as desired._
