### PR TITLE
Fix bug when building docs locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ resource_cache
 .DS_Store
 dist/*
 docs/source/release_notes.rst
+docs/source/plugins/*

--- a/docs/doc_requirements.txt
+++ b/docs/doc_requirements.txt
@@ -1,7 +1,11 @@
-lxml==5.1.0
+# File for the requirements of the documentation
+commonmark==0.9.1
 graphviz==0.20.1
-nbsphinx
-ipython
-sphinx
-sphinx_rtd_theme
-m2r
+m2r==0.2.1
+mistune==0.8.4
+nbsphinx==0.8.9
+recommonmark==0.7.1
+sphinx==5.2.3
+sphinx_rtd_theme==1.0.0
+Jinja2==3.0.3
+lxml_html_clean

--- a/docs/source/build_plugin_pages.py
+++ b/docs/source/build_plugin_pages.py
@@ -38,6 +38,9 @@ raw_html_text = """
 """
 
 
+graphs_folder = os.path.join(os.path.dirname(os.path.realpath(__file__)), "graphs")
+
+
 def add_headline(headline, output, line):
     output += headline + "\n"
     output += line * len(headline) + "\n"
@@ -206,7 +209,7 @@ def create_plugin_documentation_text(st, plugin):
 
     graph_tree = graphviz.Digraph(format="svg")
     add_deps_to_graph_tree(graph_tree, plugin, target)
-    fn = "." + "/graphs/" + target
+    fn = os.path.join(graphs_folder, target)
     graph_tree.render(fn)
     with open(f"{fn}.svg", mode="r") as f:
         svg = add_spaces(f.readlines()[5:])
@@ -250,7 +253,7 @@ def build_all_pages():
         with open(file_name, "w") as f:
             f.write(documentation)
 
-    shutil.rmtree(os.path.dirname(os.path.realpath(__file__)) + "/graphs")
+    shutil.rmtree(graphs_folder)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
_Before you submit this PR: make sure to put all XENONnT specific information in a wiki-note as the repo is publicly accessible_

## What does the code in this PR do / what does it improve?

Before this PR, when running
```
make html
```
in folder `fuse/docs`, error shows:
```
Exception occurred:
  File "/opt/miniconda3/envs/XENONnT_2024.03.1/lib/python3.9/shutil.py", line 722, in rmtree
    orig_st = os.lstat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/home/xudc/fuse/docs/source/graphs'
```

this is because the `"graphs"` folder is not defined correctly in `shutil.rmtree`

## Can you briefly describe how it works?

Define a unified path of graphs.

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Bump plugin version(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
