### PR TITLE
Fix `ChunkCsvInput` data_type of chunk

### DIFF
--- a/fuse/plugins/detector_physics/csv_input.py
+++ b/fuse/plugins/detector_physics/csv_input.py
@@ -36,7 +36,7 @@ class ChunkCsvInput(FuseBasePlugin):
     """Plugin which reads a CSV file containing instructions for the detector
     physics simulation and returns the data in chunks."""
 
-    __version__ = "0.2.1"
+    __version__ = "0.2.2"
 
     depends_on: Tuple = tuple()
     provides = "microphysics_summary"
@@ -102,9 +102,7 @@ class ChunkCsvInput(FuseBasePlugin):
 
             self.source_done = source_done
 
-            return self.chunk(
-                start=chunk_left, end=chunk_right, data=data, data_type="geant4_interactions"
-            )
+            return self.chunk(start=chunk_left, end=chunk_right, data=data)
 
         except StopIteration:
             raise RuntimeError("Bug in chunk building!")

--- a/fuse/plugins/micro_physics/input.py
+++ b/fuse/plugins/micro_physics/input.py
@@ -127,9 +127,7 @@ class ChunkInput(FuseBasePlugin):
 
             self.source_done = source_done
 
-            return self.chunk(
-                start=chunk_left, end=chunk_right, data=chunk_data, data_type="geant4_interactions"
-            )
+            return self.chunk(start=chunk_left, end=chunk_right, data=chunk_data)
 
         except StopIteration:
             raise RuntimeError("Bug in chunk building!")


### PR DESCRIPTION
_Before you submit this PR: make sure to put all XENONnT specific information in a wiki-note as the repo is publicly accessible_

## What does the code in this PR do / what does it improve?

`data_type` of `ChunkInput` should not be "geant4_interactions"

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Bump plugin version(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
