### PR TITLE
Add option to distribute Geant4 events with fixed timing

### DIFF
--- a/fuse/plugins/micro_physics/input.py
+++ b/fuse/plugins/micro_physics/input.py
@@ -28,7 +28,7 @@ class ChunkInput(FuseBasePlugin):
     and will create multiple chunks of data if needed.
     """
 
-    __version__ = "0.3.3"
+    __version__ = "0.3.4"
 
     depends_on: Tuple = tuple()
     provides = "geant4_interactions"

--- a/fuse/plugins/micro_physics/input.py
+++ b/fuse/plugins/micro_physics/input.py
@@ -123,6 +123,7 @@ class ChunkInput(FuseBasePlugin):
             entry_stop=self.entry_stop,
             cut_by_eventid=self.cut_by_eventid,
             cut_nr_only=self.nr_only,
+            fixed_event_spacing=self.fixed_event_spacing,
         )
         self.file_reader_iterator = self.file_reader.output_chunk()
 
@@ -174,6 +175,7 @@ class file_loader:
         entry_stop=None,
         cut_by_eventid=False,
         cut_nr_only=False,
+        fixed_event_spacing=False,
     ):
         self.directory = directory
         self.file_name = file_name
@@ -192,6 +194,7 @@ class file_loader:
         self.entry_stop = entry_stop
         self.cut_by_eventid = cut_by_eventid
         self.cut_nr_only = cut_nr_only
+        self.fixed_event_spacing = fixed_event_spacing
 
         self.file = os.path.join(self.directory, self.file_name)
 


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

This PR adds the option to distribute events with a fixed timing instead of using a uniform distribution.

## Can you give a minimal working example?

Setting the tracked config argument `fixed_event_spacing` from the default value `false` to `true` will set the event timings to fixed values. The event spacing is controlled by the `source_rate` argument. 

_Please include the following if applicable:_
  - [x] _Bump plugin version(s)_
  - [x] _Tests to check the (new) code is working as desired._
