### PR TITLE
Raw Records simulation acceleration in Fuse

### DIFF
--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -338,28 +338,23 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
 
         n_chunks = len(electron_chunks)
         if n_chunks > 1:
-            log.info("Chunk size exceeding file size target. " f"Downchunking to {n_chunks} chunks")
+            log.info(f"Chunk size exceeding file size target. Downchunking to {n_chunks} chunks")
 
         last_start = start
-        if n_chunks > 1:
-            for electron_group in electron_chunks[:-1]:
-                result = self.compute_chunk(interactions_in_roi, mask, electron_group)
+        for i, electron_group in enumerate(electron_chunks):
+            result = self.compute_chunk(interactions_in_roi, mask, electron_group)
 
-                # Move the chunk bound 90% of the minimal gap length to
-                # the next photon to make space for afterpluses
+            # Move the chunk bound 90% of the minimal gap length to
+            # the next photon to make space for afterpluses
+            if i < n_chunks - 1:
                 chunk_end = np.max(strax.endtime(result)) + np.int64(
                     self.min_electron_gap_length_for_splitting * 0.9
                 )
-                chunk = self.chunk(start=last_start, end=chunk_end, data=result)
-                last_start = chunk_end
-                yield chunk
-
-        # And the last chunk
-        electron_group = electron_chunks[-1]
-        result = self.compute_chunk(interactions_in_roi, mask, electron_group)
-
-        chunk = self.chunk(start=last_start, end=end, data=result)
-        yield chunk
+            else:
+                chunk_end = end
+            chunk = self.chunk(start=last_start, end=chunk_end, data=result)
+            last_start = chunk_end
+            yield chunk
 
     def compute_chunk(self, interactions_in_roi, mask, electron_group):
         unique_clusters_in_group = np.unique(electron_group["cluster_id"])

--- a/tests/test_waveform_building_functions.py
+++ b/tests/test_waveform_building_functions.py
@@ -22,12 +22,11 @@ class TestWaveformBuildingFunctions(unittest.TestCase):
             np.array([(3, 60)], dtype=[("pulse_id", int), ("time", int)]),
         ]
 
-        result, unique_pulse_ids = split_photons(propagated_photons)
+        result = split_photons(propagated_photons)
 
         self.assertEqual(len(result), len(expected_result))
         for i in range(len(result)):
             np.testing.assert_array_equal(result[i], expected_result[i])
-        np.testing.assert_array_equal(unique_pulse_ids, np.array([1, 2, 3]))
 
     def test_add_noise(self):
         # Test the add_noise function


### PR DESCRIPTION
_Before you submit this PR: make sure to put all XENONnT specific information in a wiki-note as the repo is publicly accessible_

## What does the code in this PR do / what does it improve?

The main problem in the codes before this PR:

This line https://github.com/XENONnT/fuse/blob/d5dde954301e12ebb6ec282297d98a23d47eba76/fuse/plugins/pmt_and_daq/pmt_response_and_daq.py#L380 will run `argwhere` for each `pulse["pulse_id"]`.

When the length of `unique_photon_pulse_ids` O(1e6). The running time is intolerable.

This PR first chunks the photons and then pre-processes the photons, so the first two arguments of `build_waveform`: `pulse_windows` and `photons` will have the same length. Then we do not need to run `argwhere`.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Bump plugin version(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_

[branch name](https://jojo.fandom.com/wiki/Made_in_Heaven)