### PR TITLE
Keep negative gain photons

### DIFF
--- a/fuse/common.py
+++ b/fuse/common.py
@@ -323,9 +323,6 @@ def build_photon_propagation_output(
     result["cluster_id"] = _cluster_id
     result["photon_type"] = photon_type
 
-    # Remove photons with photon_gain <= 0
-    result = result[result["photon_gain"] > 0]
-
     return result
 
 

--- a/fuse/plugins/detector_physics/s1_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s1_photon_propagation.py
@@ -33,7 +33,7 @@ class S1PhotonPropagationBase(FuseBasePlugin):
     Note: The timing calculation is defined in the child plugin.
     """
 
-    __version__ = "0.3.2"
+    __version__ = "0.3.3"
 
     depends_on = ("microphysics_summary", "s1_photon_hits")
     provides = "propagated_s1_photons"

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -33,7 +33,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
     Note: The timing calculation is defined in the child plugin.
     """
 
-    __version__ = "0.3.4"
+    __version__ = "0.3.5"
 
     depends_on = (
         "merged_electron_time",


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?
This PR relax the requirement that photon gains must be positive. This is because for the reconstruction bias we are interested is the `peak_area / num_photoelectrons - 1`. The under-amplified photons still contribute PEs and dropping them before the truth plugin can affect the result.

After fixing this, we have consistent result with SR0 WFSim result. Check [the notebook](https://github.com/XENONnT/analysiscode/blob/master/SR1_fuse_matching/peak_recon_bias.ipynb) for details.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [x] _Bump plugin version(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
