### PR TITLE
Duplicate PR 235 to see if we can pass tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,6 +47,7 @@ jobs:
           git clone https://github.com/NESTCollaboration/nestpy.git
           cd nestpy
           git submodule update --init --recursive
+          git checkout fb3804e
           pip install .
           cd ..
           rm -rf nestpy

--- a/fuse/plugins/detector_physics/electron_drift.py
+++ b/fuse/plugins/detector_physics/electron_drift.py
@@ -233,8 +233,6 @@ class ElectronDrift(FuseBasePlugin):
         y = interactions_in_roi[mask]["y"]
         z = interactions_in_roi[mask]["z"]
         n_electron = interactions_in_roi[mask]["electrons"].astype(np.int64)
-        recoil_type = interactions_in_roi[mask]["nestid"]
-        recoil_type = np.where(np.isin(recoil_type, [0, 6, 7, 8, 11]), recoil_type, 8)
 
         # Reverse engineering FDC
         if self.field_distortion_model == "inverse_fdc":

--- a/fuse/plugins/detector_physics/s1_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s1_photon_propagation.py
@@ -311,7 +311,8 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
         "&take=s1_nr_scint_time_ed_override",
         type=(int, float),
         cache=True,
-        help="This will only be used in NR scintillation dealy time. In keV unit. Overriding the energy of NEST scintillation delay model for better match to NR data.",
+        help="This will only be used in NR scintillation dealy time. In keV unit."
+        "Overriding the energy of NEST scintillation delay model for better match to NR data.",
     )
 
     s1_nr_scint_time_nesttype_override = straxen.URLConfig(
@@ -320,7 +321,8 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
         "&take=s1_nr_scint_time_nesttype_override",
         type=(int, float),
         cache=True,
-        help="This will only be used in NR scintillation dealy time. Overriding the NESTtype of NEST scintillation delay model for better match to NR data.",
+        help="This will only be used in NR scintillation dealy time."
+        "Overriding the NESTtype of NEST scintillation delay model for better match to NR data.",
     )
 
     s1_nr_scint_time_excitonfrac_override = straxen.URLConfig(
@@ -329,7 +331,8 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
         "&take=s1_nr_scint_time_excitonfrac_override",
         type=(int, float),
         cache=True,
-        help="This will only be used in NR scintillation dealy time. Overriding the exciton fraction of NEST scintillation delay model for better match to NR data.",
+        help="This will only be used in NR scintillation dealy time. Overriding the exciton" 
+        "fraction of NEST scintillation delay model for better match to NR data.",
     )
 
     def setup(self):

--- a/fuse/plugins/detector_physics/s1_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s1_photon_propagation.py
@@ -295,7 +295,7 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
         "This is used to ensure that the number of drawn photon times after truncation is greater"
         "or equal to the number of photon hits.",
     )
-    
+
     override_s1_nr_scint_time = straxen.URLConfig(
         default="take://resource://"
         "SIMULATION_CONFIG_FILE.json?&fmt=json"
@@ -313,7 +313,7 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
         cache=True,
         help="This will only be used in NR scintillation dealy time. In keV unit. Overriding the energy of NEST scintillation delay model for better match to NR data.",
     )
-    
+
     s1_nr_scint_time_nesttype_override = straxen.URLConfig(
         default="take://resource://"
         "SIMULATION_CONFIG_FILE.json?&fmt=json"
@@ -331,7 +331,6 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
         cache=True,
         help="This will only be used in NR scintillation dealy time. Overriding the exciton fraction of NEST scintillation delay model for better match to NR data.",
     )
-    
 
     def setup(self):
         super().setup()

--- a/fuse/plugins/detector_physics/s1_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s1_photon_propagation.py
@@ -331,7 +331,7 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
         "&take=s1_nr_scint_time_excitonfrac_override",
         type=(int, float),
         cache=True,
-        help="This will only be used in NR scintillation dealy time. Overriding the exciton" 
+        help="This will only be used in NR scintillation dealy time. Overriding the exciton"
         "fraction of NEST scintillation delay model for better match to NR data.",
     )
 

--- a/fuse/plugins/detector_physics/s1_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s1_photon_propagation.py
@@ -265,7 +265,7 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
     """Child plugin to simulate the propagation of S1 photons using optical
     propagation and luminescence timing from nestpy."""
 
-    __version__ = "0.3.0"
+    __version__ = "0.3.1"
 
     child_plugin = True
 


### PR DESCRIPTION
_Before you submit this PR: make sure to put all XENONnT specific information in a wiki-note as the repo is publicly accessible_

## What does the code in this PR do / what does it improve?
Duplicate #235 to see if we can pass tests. 

Cooperating with [this PR](https://github.com/XENONnT/private_nt_aux_files/pull/319). If specified scintillation delay override and we want to simulate NR, then we will override the scintillation time [here](https://github.com/XENONnT/fuse/blob/c2baf86e9e85b477f050acc97e013feb69d43593/fuse/plugins/detector_physics/s1_photon_propagation.py#L378). This is to achieve better matching between NR calibration data and simulation. No notes yet given the time pressure but I will write one and link here. For now see discussion [here](https://xenonnt.slack.com/archives/C0172947DFW/p1717613957524749) for reference.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Bump plugin version(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
