### PR TITLE
fix numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-numpy = "*"
+numpy = "<=1.26.0"
 pandas = "*"
 scipy = "*"
 scikit-learn = "*"


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

There is a problem with the latest numpy version and pandas. This PR will fix the numpy version to be equal or smaller than 1.26.0. Also see: https://stackoverflow.com/questions/78634235/numpy-dtype-size-changed-may-indicate-binary-incompatibility-expected-96-from
