### PR TITLE
Update mass and charge dtypes to int16

### DIFF
--- a/fuse/dtypes.py
+++ b/fuse/dtypes.py
@@ -48,8 +48,8 @@ csv_cluster_misc_fields = [
 
 
 cluster_misc_fields = [
-    (("Mass number of the interacting particle", "A"), np.int8),
-    (("Charge number of the interacting particle", "Z"), np.int8),
+    (("Mass number of the interacting particle", "A"), np.int16),
+    (("Charge number of the interacting particle", "Z"), np.int16),
     (("Geant4 event ID", "eventid"), np.int32),
     (("Xenon density at the cluster position", "xe_density"), np.float32),
     (("ID of the volume in which the cluster occured", "vol_id"), np.int8),


### PR DESCRIPTION
Because the maximum for int8 is 127, we get overflows when representing for example A=212 ( goes to -44). 
Moving to int16 should have no big impact and will solve the issue. 