### PR TITLE
Exciton ratio

### DIFF
--- a/fuse/dtypes.py
+++ b/fuse/dtypes.py
@@ -61,6 +61,7 @@ quanta_fields = [
     (("Number of photons at interaction position", "photons"), np.int32),
     (("Number of electrons at interaction position", "electrons"), np.int32),
     (("Number of excitons at interaction position", "excitons"), np.int32),
+    (("Ratio of excitons to photons at interaction position", "exciton_to_photon_ratio"), np.int32),
 ]
 
 

--- a/fuse/dtypes.py
+++ b/fuse/dtypes.py
@@ -61,7 +61,10 @@ quanta_fields = [
     (("Number of photons at interaction position", "photons"), np.int32),
     (("Number of electrons at interaction position", "electrons"), np.int32),
     (("Number of excitons at interaction position", "excitons"), np.int32),
-    (("Ratio of excitons to photons at interaction position", "exciton_to_photon_ratio"), np.int32),
+    (
+        ("Ratio of excitons to photons at interaction position", "exciton_to_photon_ratio"),
+        np.float32,
+    ),
 ]
 
 

--- a/fuse/plugins/detector_physics/s1_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s1_photon_propagation.py
@@ -188,7 +188,7 @@ class S1PhotonPropagationBase(FuseBasePlugin):
             positions=positions,
             e_dep=instruction["ed"],
             n_photons_emitted=n_photons,
-            n_excitons=instruction["excitons"].astype(np.int64),
+            exciton_to_photon_ratio=instruction["exciton_to_photon_ratio"],
             local_field=instruction["e_field"],
         )
 
@@ -348,7 +348,7 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
         positions,
         e_dep,
         n_photons_emitted,
-        n_excitons,
+        exciton_to_photon_ratio,
         local_field,
     ):
         """Calculate distribution of photon arrival timnigs
@@ -361,7 +361,7 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
             positions: nx3 array of true XYZ positions from instruction
             e_dep: energy of the deposit, 1d float array
             n_photons_emitted: number of orignally emitted photons/quanta, 1d int array
-            n_excitons: number of exctions in deposit, 1d int array
+            exciton_to_photon_ratio: Ratio of exctions to photons of the deposit, 1d int array
             local_field: local field in the point of the deposit, 1d array of floats
         Returns:
             photon timing array
@@ -381,7 +381,7 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
             n_photon_hits=n_photon_hits,
             n_photons_emitted=n_photons_emitted,
             recoil_type=recoil_type,
-            n_excitons=n_excitons,
+            exciton_to_photon_ratio=exciton_to_photon_ratio,
             local_field=local_field,
             e_dep=e_dep,
         )
@@ -389,7 +389,13 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
         return _photon_timings
 
     def nest_scintillation_timing(
-        self, n_photon_hits, n_photons_emitted, recoil_type, n_excitons, local_field, e_dep
+        self,
+        n_photon_hits,
+        n_photons_emitted,
+        recoil_type,
+        exciton_to_photon_ratio,
+        local_field,
+        e_dep,
     ):
 
         assert np.all(
@@ -421,7 +427,7 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
                     scint_time = self.nestpy_calc.GetPhotonTimes(
                         nestpy.INTERACTION_TYPE(recoil_type[i]),
                         n_times_to_sample,
-                        n_excitons[i],
+                        exciton_to_photon_ratio[i] * n_times_to_sample,
                         local_field[i],
                         e_dep[i],
                     )

--- a/fuse/plugins/detector_physics/s1_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s1_photon_propagation.py
@@ -427,7 +427,7 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
                     scint_time = self.nestpy_calc.GetPhotonTimes(
                         nestpy.INTERACTION_TYPE(recoil_type[i]),
                         n_times_to_sample,
-                        exciton_to_photon_ratio[i] * n_times_to_sample,
+                        round(exciton_to_photon_ratio[i] * n_times_to_sample),
                         local_field[i],
                         e_dep[i],
                     )

--- a/fuse/plugins/detector_physics/s1_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s1_photon_propagation.py
@@ -260,7 +260,7 @@ class S1PhotonPropagation(S1PhotonPropagationBase):
     """Child plugin to simulate the propagation of S1 photons using optical
     propagation and luminescence timing from nestpy."""
 
-    __version__ = "0.3.1"
+    __version__ = "0.3.2"
 
     child_plugin = True
 

--- a/fuse/plugins/micro_physics/yields.py
+++ b/fuse/plugins/micro_physics/yields.py
@@ -64,7 +64,9 @@ class NestYields(FuseBasePlugin):
             result["photons"] = photons
             result["electrons"] = electrons
             result["excitons"] = excitons
-            result["exciton_to_photon_ratio"] = excitons / photons
+            result["exciton_to_photon_ratio"] = np.divide(
+                excitons, photons, out=np.zeros_like(photons), where=photons != 0
+            )
         else:
             result["photons"] = np.empty(0)
             result["electrons"] = np.empty(0)

--- a/fuse/plugins/micro_physics/yields.py
+++ b/fuse/plugins/micro_physics/yields.py
@@ -19,7 +19,7 @@ class NestYields(FuseBasePlugin):
     """Plugin that calculates the number of photons, electrons and excitons
     produced by energy deposit using nestpy."""
 
-    __version__ = "0.2.2"
+    __version__ = "0.2.3"
 
     depends_on = ("interactions_in_roi", "electric_field_values")
     provides = "quanta"

--- a/fuse/plugins/micro_physics/yields.py
+++ b/fuse/plugins/micro_physics/yields.py
@@ -65,8 +65,11 @@ class NestYields(FuseBasePlugin):
             result["electrons"] = electrons
             result["excitons"] = excitons
             result["exciton_to_photon_ratio"] = np.divide(
-                excitons, photons, out=np.zeros_like(photons), where=photons != 0
-            )
+                excitons.astype(np.float32),
+                photons.astype(np.float32),
+                out=np.zeros(len(photons), dtype=np.float32),
+                where=photons != 0,
+            ).astype(np.float32)
         else:
             result["photons"] = np.empty(0)
             result["electrons"] = np.empty(0)

--- a/fuse/plugins/micro_physics/yields.py
+++ b/fuse/plugins/micro_physics/yields.py
@@ -64,10 +64,12 @@ class NestYields(FuseBasePlugin):
             result["photons"] = photons
             result["electrons"] = electrons
             result["excitons"] = excitons
+            result["exciton_to_photon_ratio"] = excitons / photons
         else:
             result["photons"] = np.empty(0)
             result["electrons"] = np.empty(0)
             result["excitons"] = np.empty(0)
+            result["exciton_to_photon_ratio"] = np.empty(0)
 
         # Unlock the nest random generator seed again
         nest_rng.unlock_seed()

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -15,7 +15,8 @@ def build_random_instructions(n):
 
     df["photons"] = np.random.uniform(100, 5000, n)
     df["electrons"] = np.random.uniform(100, 5000, n)
-    df["excitons"] = np.zeros(n)
+    df["excitons"] = df["photons"]
+    df["exciton_to_photon_ratio"] = np.ones(n)  # Lets use a ratio of 1 for the tests.
 
     df["e_field"] = np.array([23] * n)
     df["nestid"] = np.array([7] * n)


### PR DESCRIPTION
## What does the code in this PR do / what does it improve?

This PR will exchange the number of excitons in the S1 timing simulation by the ratio of excitons to photons. It aims at solving https://github.com/XENONnT/fuse/issues/239. 

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Bump plugin version(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
