### PR TITLE
Fix lineage algo - RadioactiveDecayBase

### DIFF
--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -27,7 +27,7 @@ class LineageClustering(FuseBasePlugin):
     and its parent.
     """
 
-    __version__ = "0.0.26"
+    __version__ = "0.0.27"
 
     depends_on = "geant4_interactions"
 
@@ -445,11 +445,15 @@ def is_lineage_broken(
     # For gamma rays, check the distance between the parent and the particle
     if particle["type"] == "gamma":
 
-        if ((particle["creaproc"] == "phot" and particle["edproc"] == "phot") or
-            parent_lineage["lineage_type"] == 7):
+        if (particle["creaproc"] == "phot" and particle["edproc"] == "phot"):
             # We do not want to split a photo absorption into two clusters
             # The second photo absorption (that we see) could be x rays
             # So, do not split if the distance is small
+            return False
+
+        if ((parent_lineage["lineage_type"] == 7) and 
+            not (parent["creaproc"] == "RadioactiveDecayBase" 
+            and parent["edproc"] == "RadioactiveDecayBase")):
             # Same as for the previous case
             # We are already in the middle of a gamma full absorption
             # Let's not split the lineage (gamma rays, etc.)

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -27,7 +27,7 @@ class LineageClustering(FuseBasePlugin):
     and its parent.
     """
 
-    __version__ = "0.0.28"
+    __version__ = "0.0.29"
 
     depends_on = "geant4_interactions"
 

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -180,7 +180,7 @@ class LineageClustering(FuseBasePlugin):
                         if "[" in particle["type"]:
                             secondaries = get_all_particle_secondaries(event, particle)
                         else:
-                            secondaries = None                        
+                            secondaries = None
 
                         tmp_result = start_new_lineage(
                             particle, tmp_result, i, running_lineage_index, secondaries
@@ -197,7 +197,7 @@ class LineageClustering(FuseBasePlugin):
                     if "[" in particle["type"]:
                         secondaries = get_all_particle_secondaries(event, particle)
                     else:
-                        secondaries = None      
+                        secondaries = None
 
                     tmp_result = start_new_lineage(
                         particle, tmp_result, i, running_lineage_index, secondaries
@@ -222,11 +222,10 @@ class LineageClustering(FuseBasePlugin):
                         # New lineage!
                         running_lineage_index += 1
 
-
                         if "[" in particle["type"]:
                             secondaries = get_all_particle_secondaries(event, particle)
                         else:
-                            secondaries = None      
+                            secondaries = None
 
                         tmp_result = start_new_lineage(
                             particle, tmp_result, i, running_lineage_index, secondaries
@@ -304,10 +303,12 @@ def get_parent(event_interactions, event_lineage, particle):
 
 def get_all_particle_secondaries(event_interactions, particle):
     """Returns all secondaries of the given particle.
-    It iterates over all interactions of the event and checks if the parent id
-    of the interaction is the same as the track id of the particle, and continues
-    down the tree until no more secondaries are found or a RadioactiveDecayBase
-    type interaction is found."""
+
+    It iterates over all interactions of the event and checks if the
+    parent id of the interaction is the same as the track id of the
+    particle, and continues down the tree until no more secondaries are
+    found or a RadioactiveDecayBase type interaction is found.
+    """
 
     secondaries = []
     parent_id = particle["trackid"]
@@ -316,6 +317,7 @@ def get_all_particle_secondaries(event_interactions, particle):
             secondaries.append(interaction)
 
     return secondaries
+
 
 def is_particle_in_lineage(lineage):
     """Function to check if a particle is already in a lineage."""
@@ -338,11 +340,11 @@ def classify_lineage(particle_interaction, secondaries=None):
     # Check if we passed secondaries
     if secondaries is not None:
         for secondary in secondaries:
-            # there is a seconday that has type gamma and edproc phot, 
+            # there is a seconday that has type gamma and edproc phot,
             # we classify this lineage as beta because it is most likely a compton scattering
-            if (secondary["type"] == "e-"):
+            if secondary["type"] == "e-":
                 return NEST_GAMMA
-            
+
         return NEST_BETA
 
     # NR interactions
@@ -427,30 +429,35 @@ def is_lineage_broken(
 ):
     """Function to check if the lineage is broken."""
 
-
-    if particle["creaproc"] == "RadioactiveDecayBase" \
-        and particle["edproc"] == "RadioactiveDecayBase":
+    if (
+        particle["creaproc"] == "RadioactiveDecayBase"
+        and particle["edproc"] == "RadioactiveDecayBase"
+    ):
         # second step of a decay. We want to split the lineage
         return True
 
     # In the nest code: Lineage is always broken if the parent is a ion
     # But if it's an alpha particle, we want to keep the lineage
-    if (num_there(parent["type"])) \
-        and ("[" not in parent["type"]) \
-        and (parent["parenttype"] == "none") \
-        and (particle["type"] != "alpha"):
+    if (
+        (num_there(parent["type"]))
+        and ("[" not in parent["type"])
+        and (parent["parenttype"] == "none")
+        and (particle["type"] != "alpha")
+    ):
         return True
 
-    if (num_there(parent["type"]))      \
-        and ("[" not in parent["type"]) \
-        and (parent["creaproc"] == "RadioactiveDecayBase") \
-        and (particle["type"] != "alpha"):
+    if (
+        (num_there(parent["type"]))
+        and ("[" not in parent["type"])
+        and (parent["creaproc"] == "RadioactiveDecayBase")
+        and (particle["type"] != "alpha")
+    ):
         return True
 
     # For gamma rays, check the distance between the parent and the particle
     if particle["type"] == "gamma":
 
-        if (particle["creaproc"] == "phot" and particle["edproc"] == "phot"):
+        if particle["creaproc"] == "phot" and particle["edproc"] == "phot":
             # We do not want to split a photo absorption into two clusters
             # The second photo absorption (that we see) could be x rays
             # So, do not split if the distance is small
@@ -469,7 +476,6 @@ def is_lineage_broken(
         if parent["edproc"] == "Transportation":
             return True
 
-
         particle_position = np.array([particle["x"], particle["y"], particle["z"]])
         parent_position = np.array([parent["x"], parent["y"], parent["z"]])
         distance = np.sqrt(np.sum((parent_position - particle_position) ** 2, axis=0))
@@ -477,7 +483,7 @@ def is_lineage_broken(
         if particle["creaproc"] == "eBrem":
             # we do not want to split a bremsstrahlung into two clusters
             # if the distance is really small, it is most likely the same interaction
-            if distance < 0.1: # cm
+            if distance < 0.1:  # cm
                 return False
 
         if distance > gamma_distance_threshold:

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -343,17 +343,16 @@ def classify_lineage(particle_interaction, secondaries=None):
     """Function to classify a new lineage based on the particle and its parent
     information."""
 
-    # Check if we passed secondaries: it means that the particle is a nucleus excitation
+    # Check if we passed secondaries (we treat here a special case):
+    # it means that the particle is a nucleus excitation with a [..] in the name
     if secondaries is not None:
         for secondary in secondaries:
-            # if there is any secondary that is an electron, 
-            # we classify it as gamma (this is the case for photoabsorption)
+            # If there is any secondary that is an electron, 
+            # we classify it as gamma (this is the case for photoabsorption).
+            # For high energy gammas, we will have type gamma secondaries
+            # either gamma-phot or gamma-compt (or gamma-conv) without any e-.
             if secondary["type"] == "e-":
                 return NEST_GAMMA
-
-        # If there are no electrons, it's probably compton
-        # starting with a gamma compt interaction
-        return NEST_BETA
 
     # NR interactions
     if (particle_interaction["parenttype"] == "neutron") & (

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -336,24 +336,20 @@ def classify_lineage(particle_interaction, secondaries=None):
     """Function to classify a new lineage based on the particle and its parent
     information."""
 
-    # Check if we have secondaries
+    # Check if we passed secondaries
     if secondaries is not None:
-        # if there is a seconday that has
-        # type gamma and edproc phot, we classify the lineage as beta
-
-        print(f"******* Checking secondaries for event {particle_interaction['eventid']}")
-
         for secondary in secondaries:
+            # there is a seconday that has type gamma and edproc phot, 
+            # we classify this lineage as beta because it is most likely a compton scattering
             if (secondary["type"] == "gamma") and (secondary["edproc"] == "phot"):
-                print("Found a secondary gamma with edproc phot. Classifying as beta")
                 return NEST_BETA
-
+            # there is a seconday that has edproc transportation,
+            # we classify this lineage as beta because it is most likely a compton scattering
             if (secondary["edproc"] == "Transportation"):
-                print("Found a secondary gamma with edproc Transportation. Classifying as beta")
                 return NEST_BETA
-
-        print("No secondary gamma with edproc phot found. Classifying as gamma")
-
+        
+        # otherwise we classify the lineage as gamma
+        # because it is most likely a photoabsorption ( we assume only one photoabsorption )
         return NEST_GAMMA
 
     # NR interactions

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -397,18 +397,8 @@ def classify_lineage(particle_interaction, secondaries=None):
 
         # Ions
         elif num_there(particle_interaction["type"]):
-            if "[" in particle_interaction["type"]:
-                # Most likely a gamma. Classify it as gamma
-                # AHAHA
-                # We should study the secondaries and understand what is going on
-                # Could be comppton or absorption
-                # return NEST_GAMMA
-                # TODO
-                pass
-
-            else:
-                element_number, mass = get_element_and_mass(particle_interaction["type"])
-                return 6, mass, element_number
+            element_number, mass = get_element_and_mass(particle_interaction["type"])
+            return 6, mass, element_number
 
         else:
             # This case should not happen or? Classify it as nontype

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -1,7 +1,6 @@
 import numpy as np
 import strax
 import straxen
-from numba import njit
 
 import re
 import periodictable as pt
@@ -27,7 +26,7 @@ class LineageClustering(FuseBasePlugin):
     and its parent.
     """
 
-    __version__ = "0.0.29"
+    __version__ = "0.0.2"
 
     depends_on = "geant4_interactions"
 

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -27,7 +27,7 @@ class LineageClustering(FuseBasePlugin):
     and its parent.
     """
 
-    __version__ = "0.0.25"
+    __version__ = "0.0.26"
 
     depends_on = "geant4_interactions"
 
@@ -445,6 +445,16 @@ def is_lineage_broken(
     # For gamma rays, check the distance between the parent and the particle
     if particle["type"] == "gamma":
 
+        if ((particle["creaproc"] == "phot" and particle["edproc"] == "phot") or
+            parent_lineage["lineage_type"] == 7):
+            # We do not want to split a photo absorption into two clusters
+            # The second photo absorption (that we see) could be x rays
+            # So, do not split if the distance is small
+            # Same as for the previous case
+            # We are already in the middle of a gamma full absorption
+            # Let's not split the lineage (gamma rays, etc.)
+            return False
+
         # Break the lineage for these transportation gammas
         # Transportations is a special case. They are not real gammas.
         # They are just used to transport the energy
@@ -455,14 +465,7 @@ def is_lineage_broken(
 
         particle_position = np.array([particle["x"], particle["y"], particle["z"]])
         parent_position = np.array([parent["x"], parent["y"], parent["z"]])
-
         distance = np.sqrt(np.sum((parent_position - particle_position) ** 2, axis=0))
-
-        if (particle["creaproc"] == "phot") and (particle["edproc"] == "phot"):
-            # we do not want to split a photo absorption into two clusters
-            # the second photo absorbtion (that we see) could be x rays
-            # so, do not split if the distance is small
-            return False
 
         if particle["creaproc"] == "eBrem":
             # we do not want to split a bremsstrahlung into two clusters

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -27,7 +27,7 @@ class LineageClustering(FuseBasePlugin):
     and its parent.
     """
 
-    __version__ = "0.0.24"
+    __version__ = "0.0.25"
 
     depends_on = "geant4_interactions"
 
@@ -444,11 +444,6 @@ def is_lineage_broken(
 
     # For gamma rays, check the distance between the parent and the particle
     if particle["type"] == "gamma":
-
-        if "[" in particle["parenttype"]:
-            # This is just a secondary gamma. We do not want to split the lineage
-            return False
-
 
         # Break the lineage for these transportation gammas
         # Transportations is a special case. They are not real gammas.

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -198,9 +198,7 @@ class LineageClustering(FuseBasePlugin):
                     # Particle without parent. Start a new lineage
                     running_lineage_index += 1
 
-                    tmp_result = start_new_lineage(
-                        particle, tmp_result, i, running_lineage_index
-                    )
+                    tmp_result = start_new_lineage(particle, tmp_result, i, running_lineage_index)
 
             else:
                 # We have seen this particle before. Now evaluate if we have to break the lineage

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -342,8 +342,8 @@ def classify_lineage(particle_interaction, secondaries=None):
             # we classify this lineage as beta because it is most likely a compton scattering
             if (secondary["type"] == "e-"):
                 return NEST_GAMMA
-            else:
-                return NEST_BETA
+            
+        return NEST_BETA
 
     # NR interactions
     if (particle_interaction["parenttype"] == "neutron") & (

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -27,7 +27,7 @@ class LineageClustering(FuseBasePlugin):
     and its parent.
     """
 
-    __version__ = "0.0.27"
+    __version__ = "0.0.28"
 
     depends_on = "geant4_interactions"
 
@@ -342,6 +342,8 @@ def classify_lineage(particle_interaction, secondaries=None):
             # we classify this lineage as beta because it is most likely a compton scattering
             if (secondary["type"] == "e-"):
                 return NEST_GAMMA
+            else:
+                return NEST_BETA
 
     # NR interactions
     if (particle_interaction["parenttype"] == "neutron") & (
@@ -399,7 +401,10 @@ def classify_lineage(particle_interaction, secondaries=None):
                 # AHAHA
                 # We should study the secondaries and understand what is going on
                 # Could be comppton or absorption
-                return NEST_GAMMA
+                # return NEST_GAMMA
+                # TODO
+                pass
+
             else:
                 element_number, mass = get_element_and_mass(particle_interaction["type"])
                 return 6, mass, element_number
@@ -451,9 +456,7 @@ def is_lineage_broken(
             # So, do not split if the distance is small
             return False
 
-        if ((parent_lineage["lineage_type"] == 7) and 
-            not (parent["creaproc"] == "RadioactiveDecayBase" 
-            and parent["edproc"] == "RadioactiveDecayBase")):
+        if parent_lineage["lineage_type"] == 7:
             # Same as for the previous case
             # We are already in the middle of a gamma full absorption
             # Let's not split the lineage (gamma rays, etc.)


### PR DESCRIPTION
With this PR we fix some issues with the treatment of RadioactiveDecayBase (RDB) interactions. I realised that the results of simulating one gamma and simulating the gamma from Xe131 gave very different results. That is not good. Now they both give similar results. 

Specifically, we had to add special treatment for gammas emitted from excited nuclei that are treated by RDB library. 
Low energy gammas will not produce a gamma-phot/compt interaction in G4 just like hig energy gammas, but just some electron tracks and some gamma tracks will be produced. Now, we decide based on the secondaries what yield to assign to a certain cluster. The modifications match perfectly the distributions of Xe129 and Xe133 ( they were completely off before this PR ) and also match much better Pb212. 

## Details of changes: 

- If there is "[" in the particle type ( like Xe129[236.140] ) - we pass also the secondaries to the classification. We need them to understand if to give a gamma or beta yield.
- Added get_particle_secondaries function to get first order daughters of a particle
- classification with secondaries: if there are only gammas -> it's a beta yield compton. If there are also electrons, it's probably a low energy gamma, so gets a gamma yield. 
- lineage broken: brake if creaproc and edproc are both RDB. Intermediate step. 
- modify ion lineage broken. before: brake if lineage is 6, now checks if ion. 
- added: if lineage is a gamma yield, never brake anymore. We don't want to split photoabsorb. 
- added: 0.1cm threshold specially for brem. 


#### Xe129 - 39keV gamma
It makes some electron tracks and some gamma-phots. We want to keep them all together into a one gamma cluster. 


![Xe129_39kev](https://github.com/user-attachments/assets/2f91838b-3cea-4409-90b7-92cf4393326c)

#### Xe129 - 196keV gamma
It makes some electron tracks. Again, we want to keep them all together into a one gamma cluster. 


![Xe129_196kev](https://github.com/user-attachments/assets/76bb8296-d866-4853-8d3e-1dfbc9dde79c)

#### Bi214 - 609keV gamma
It makes a real gamma. The gamma produces two compton clusters ( beta yield ) and one photoabsorbtion ( gamma yield ) 


![BiPo_609kev](https://github.com/user-attachments/assets/931053de-2f3b-4030-994a-893cb330b09b)


 ## Summary of clustering for different situations

Left: NEW clustering 
Right: OLD clustering

#### Gamma simulations 163keV in TPC
Expect just one gamma cluster, sometimes compton + gamma

<img width="1252" alt="Gamma_summary" src="https://github.com/user-attachments/assets/eaecbcf7-5eec-41d7-a57b-206ea9c3f1a7">

#### Pb212
It's gammas+beta most of the times, with 238keV gamma

<img width="1254" alt="Pb212_summary" src="https://github.com/user-attachments/assets/96618c04-b8eb-43d2-b51e-6ee1197bd016">

# Xe131
It's one 163keV gamma
<img width="1239" alt="Xe131_summary" src="https://github.com/user-attachments/assets/e13d1acc-da4e-447b-816b-5353f737d8ac">

# Xe129
It's two different gammas
<img width="1221" alt="Xe129_summary" src="https://github.com/user-attachments/assets/37d82fc7-836d-45e9-8037-8749604616d0">

# BiPo
there is gamma+beta and then alpha
<img width="1257" alt="BiPo_summary" src="https://github.com/user-attachments/assets/aa12a304-6a35-42af-a040-06154cafdbfa">


