### PR TITLE
pulse_id type casting inconsistency

### DIFF
--- a/fuse/plugins/pmt_and_daq/photon_pulses.py
+++ b/fuse/plugins/pmt_and_daq/photon_pulses.py
@@ -170,7 +170,7 @@ def concat_overlapping_hits(hits, extensions, pmt_channels, start, end):
             strax.interval_dtype
             + [
                 (("End time of the interval (ns since unix epoch)", "endtime"), np.int64),
-                (("pulse_id"), np.int64),
+                ((("ID of the pulse window", "pulse_id")), np.int64),
             ]
         ),
     )
@@ -192,7 +192,7 @@ def concat_overlapping_hits(hits, extensions, pmt_channels, start, end):
     return hits, photon_identifiers
 
 
-pulse_dtype = strax.interval_dtype + [(("pulse_id"), np.int64)]
+pulse_dtype = strax.interval_dtype + [((("ID of the pulse window", "pulse_id")), np.int64)]
 
 
 @strax.utils.growing_result(pulse_dtype, chunk_size=int(1e4))


### PR DESCRIPTION

While checking out why I am getting `numpy.exceptions.DTypePromotionError: field titles of field 'pulse_id' mismatch` I found this error with Henning and after changing the casting to be consistent it seems to have vanished.