### PR TITLE
Fix chunk ends late issue

### DIFF
--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -276,7 +276,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
 
     min_electron_gap_length_for_splitting = straxen.URLConfig(
         type=(int, float),
-        default=1e5,
+        default=2e6,
         track=False,
         help="Chunk can not be split if gap between photons is smaller than this value given in ns",
     )


### PR DESCRIPTION
We increase the default value for the `min_electron_gap_length_for_splitting`.  This defines the time windows to split chunks at s2 photon propagation.

This was creating issues when afterpulses of large S2s would go out of the chunk boundaries. For some high energy simulations (BiPos with ~5k events/job) this was having a fail rate of ~50% of jobs submitted. With the new configuration the issue now appears less than 1%. 

The errors would be of the type: 

```
ValueError: Attempt to create chunk (00009.pulse_windows: 1565sec 869075581 ns - 1777sec 483266062 ns, 74217 items, 0.0 MB/s) whose data ends late at 1777483266961
```

and it created problems with different plugins, see here out of 393 submittet jobs the plugin that failed:

```
Total number of files scanned: 393
Total number of files with the pattern: 201
Summary of chunk types (from last occurrence per file):
  raw_records: 9
  pulse_windows: 36
  pmt_afterpulses: 156
```

with the new configuration only 3 runs failed. 

Note that this change does not produce lineage change.

Thank you very much to @HenningSE for taking the time to look into this and identify the problem and find a solution :)