### PR TITLE
Move context to fuse

### DIFF
--- a/fuse/__init__.py
+++ b/fuse/__init__.py
@@ -10,3 +10,4 @@ from .vertical_merger_plugin import *
 from .volume_plugin import *
 
 from .context import *
+from .context_utils import *

--- a/fuse/context.py
+++ b/fuse/context.py
@@ -18,7 +18,7 @@ if hasattr(straxen.contexts, "xnt_common_opts"):
     common_opts = straxen.contexts.xnt_common_opts
     common_config = straxen.contexts.xnt_common_config
 else:
-    # This is for straxen >=3, variable names changed    
+    # This is for straxen >=3, variable names changed
     common_opts = straxen.contexts.common_opts
     common_config = common_config
 
@@ -111,9 +111,7 @@ def microphysics_context(
 
     st = strax.Context(storage=strax.DataDirectory(output_folder), **common_opts)
 
-    st.config.update(
-        dict(detector="XENONnT", check_raw_record_overlaps=True, **common_config)
-    )
+    st.config.update(dict(detector="XENONnT", check_raw_record_overlaps=True, **common_config))
 
     # Register microphysics plugins
     for plugin in microphysics_plugins_dbscan_clustering:
@@ -166,11 +164,7 @@ def full_chain_context(
     st.simulation_config_file = simulation_config_file
     st.corrections_run_id = corrections_run_id
 
-    st.config.update(
-        dict(  # detector='XENONnT',
-            check_raw_record_overlaps=True, **common_config
-        )
-    )
+    st.config.update(dict(check_raw_record_overlaps=True, **common_config))  # detector='XENONnT',
 
     # Register microphysics plugins
     if clustering_method == "dbscan":

--- a/fuse/context.py
+++ b/fuse/context.py
@@ -12,6 +12,17 @@ import fuse
 logging.basicConfig(handlers=[logging.StreamHandler()])
 log = logging.getLogger("fuse.context")
 
+# Determine which config names to use (backward compatibility)
+if hasattr(straxen.contexts, "xnt_common_opts"):
+    # This is for straxen <=2
+    common_opts = straxen.contexts.xnt_common_opts
+    common_config = straxen.contexts.xnt_common_config
+else:
+    # This is for straxen >=3, variable names changed    
+    common_opts = straxen.contexts.common_opts
+    common_config = common_config
+
+
 # Plugins to simulate microphysics
 microphysics_plugins_dbscan_clustering = [
     fuse.micro_physics.ChunkInput,
@@ -98,10 +109,10 @@ def microphysics_context(
 ):
     """Function to create a fuse microphysics simulation context."""
 
-    st = strax.Context(storage=strax.DataDirectory(output_folder), **straxen.contexts.common_opts)
+    st = strax.Context(storage=strax.DataDirectory(output_folder), **common_opts)
 
     st.config.update(
-        dict(detector="XENONnT", check_raw_record_overlaps=True, **straxen.contexts.common_config)
+        dict(detector="XENONnT", check_raw_record_overlaps=True, **common_config)
     )
 
     # Register microphysics plugins
@@ -151,13 +162,13 @@ def full_chain_context(
             "Take the context defined in cutax if you want to run XENONnT simulations."
         )
 
-    st = strax.Context(storage=strax.DataDirectory(output_folder), **straxen.contexts.common_opts)
+    st = strax.Context(storage=strax.DataDirectory(output_folder), **common_opts)
     st.simulation_config_file = simulation_config_file
     st.corrections_run_id = corrections_run_id
 
     st.config.update(
         dict(  # detector='XENONnT',
-            check_raw_record_overlaps=True, **straxen.contexts.common_config
+            check_raw_record_overlaps=True, **common_config
         )
     )
 

--- a/fuse/context.py
+++ b/fuse/context.py
@@ -1,5 +1,4 @@
 # mypy: ignore-errors
-
 from copy import deepcopy
 import logging
 
@@ -9,8 +8,29 @@ import straxen
 from straxen import URLConfig
 import fuse
 
+from .context_utils import (
+    write_sr_information_to_config,
+    set_simulation_config_file,
+    old_xedocs_versions_patch
+)
+
 logging.basicConfig(handlers=[logging.StreamHandler()])
 log = logging.getLogger("fuse.context")
+
+DEFAULT_XEDOCS_VERSION = "global_v16"
+DEFAULT_SIMULATION_VERSION = "sr1_dev"
+
+# This we could easily find a way to move it to the simulation config file
+SCIENCE_RUN_DEFAULT_RUN_ID = {
+    "sr0": "026000",
+    "sr1": "046477"
+}
+
+# This we could easily find a way to move it to the simulation config file
+SCIENCE_RUN_MC_FDC = {
+    "sr0": "XnT_3D_FDC_xyz_24_Jun_2022_MC.json.gz",
+    "sr1": "XnT_3D_FDC_xyz_SR1_15_Mar_2024_MC.json.gz"
+}
 
 # Determine which config names to use (backward compatibility)
 if hasattr(straxen.contexts, "xnt_common_opts"):
@@ -102,7 +122,6 @@ truth_information_plugins = [
 processing_plugins = [
     fuse.processing.CorrectedAreasMC,
 ]
-
 
 def microphysics_context(
     output_folder="./fuse_data", simulation_config_file="fuse_config_nt_sr1_dev.json"
@@ -237,108 +256,71 @@ def full_chain_context(
     st.deregister_plugins_with_missing_dependencies()
 
     # Purge unused configs (only for newer strax)
-    try:
+    if hasattr(st, "purge_unused_configs"):
         st.purge_unused_configs()
-    except:
-        pass
 
     return st
 
 
-def set_simulation_config_file(context, config_file_name):
-    """Function to loop over the plugin config and replace
-    SIMULATION_CONFIG_FILE with the actual file name."""
-    for data_type, plugin in context._plugin_class_registry.items():
-        for option_key, option in plugin.takes_config.items():
-            if isinstance(option.default, str) and "SIMULATION_CONFIG_FILE.json" in option.default:
-                context.config[option_key] = option.default.replace(
-                    "SIMULATION_CONFIG_FILE.json", config_file_name
-                )
-
-            # Special case for the photoionization_modifier
-            if option_key == "photoionization_modifier":
-                context.config[option_key] = option.default
-
-
-@URLConfig.register("pattern_map")
-def pattern_map(map_data, pmt_mask, method="WeightedNearestNeighbors"):
-    """Pattern map handling."""
-
-    if "compressed" in map_data:
-        compressor, dtype, shape = map_data["compressed"]
-        map_data["map"] = np.frombuffer(
-            strax.io.COMPRESSORS[compressor]["decompress"](map_data["map"]), dtype=dtype
-        ).reshape(*shape)
-        del map_data["compressed"]
-    if "quantized" in map_data:
-        map_data["map"] = map_data["quantized"] * map_data["map"].astype(np.float32)
-        del map_data["quantized"]
-    if not (pmt_mask is None):
-        assert (
-            map_data["map"].shape[-1] == pmt_mask.shape[0]
-        ), "Error! Pattern map and PMT gains must have same dimensions!"
-        map_data["map"][..., ~pmt_mask] = 0.0
-    return straxen.InterpolatingMap(map_data, method=method)
-
-
-@URLConfig.register("s2_aft_scaling")
-def modify_s2_pattern_map(
-    s2_pattern_map, s2_mean_area_fraction_top, n_tpc_pmts, n_top_pmts, turned_off_pmts
+def xenonnt_fuse_full_chain_simulation(
+    output_folder="./fuse_data",
+    corrections_version=DEFAULT_XEDOCS_VERSION,
+    simulation_config=DEFAULT_SIMULATION_VERSION,
+    corrections_run_id=None, 
+    fdc_map_mc=None,
+    cut_list=None,
+    **kwargs,
 ):
-    """Modify the S2 pattern map to match a given input AFT."""
-    if s2_mean_area_fraction_top > 0:
-        s2map = deepcopy(s2_pattern_map)
-        # First we need to set turned off pmts before scaling
-        s2map.data["map"][..., turned_off_pmts] = 0
-        s2map_topeff_ = s2map.data["map"][..., :n_top_pmts].sum(axis=2, keepdims=True)
-        s2map_toteff_ = s2map.data["map"].sum(axis=2, keepdims=True)
-        orig_aft_ = np.nanmean(s2map_topeff_ / s2map_toteff_)
-        # Getting scales for top/bottom separately to preserve total efficiency
-        scale_top_ = s2_mean_area_fraction_top / orig_aft_
-        scale_bot_ = (1 - s2_mean_area_fraction_top) / (1 - orig_aft_)
-        s2map.data["map"][..., :n_top_pmts] *= scale_top_
-        s2map.data["map"][..., n_top_pmts:n_tpc_pmts] *= scale_bot_
-        s2_pattern_map.__init__(s2map.data)
-    return s2_pattern_map
+    """Function to create a fuse full chain simulation context
+    with the proper settings for XENONnT simulations.
+    It takes the general full_chain_context and sets the
+    proper corrections and configuration files for XENONnT.
+    """
+
+    import fuse
+
+    if "/" in simulation_config:
+        simulation_config_file = simulation_config
+    else:
+        simulation_config_file = "fuse_config_nt_{:s}.json".format(simulation_config)
+
+    if corrections_run_id is None:
+        corrections_run_id = SCIENCE_RUN_DEFAULT_RUN_ID.get(simulation_config.split("_")[0], None)
+        if corrections_run_id is None:
+            raise ValueError(
+                f"The automatic run_id for {simulation_config} is not known. \
+                Please specify a corrections_run_id or a simulation_config_file that \
+                starts with srX_ where X is the science run number."
+            )
+        
+    st = fuse.full_chain_context(
+        output_folder=output_folder,
+        corrections_version=corrections_version,
+        simulation_config_file=simulation_config_file,
+        corrections_run_id=corrections_run_id,
+        **kwargs,
+    )
+    st.set_config(old_xedocs_versions_patch(corrections_version))
 
 
-# Probably not needed!
-@URLConfig.register("simple_load")
-def load(data):
-    """Some Documentation."""
-    return data
+    if fdc_map_mc is None:
+        fdc_map_mc = SCIENCE_RUN_MC_FDC.get(simulation_config.split("_")[0], None)
+        if fdc_map_mc is None:
+            raise ValueError(
+                f"The automatic fdc_map_mc for {simulation_config} is not known. \
+                Please specify a fdc_map_mc or a simulation_config_file that \
+                starts with srX_ where X is the science run number."
+            )
+    
+    if fdc_map_mc:
+        fdc_ext = fdc_map_mc.split(fdc_map_mc.split(".")[0] + ".")[-1]
+        fdc_conf = f"itp_map://resource://{fdc_map_mc}?fmt={fdc_ext}"
+        st.set_config({"fdc_map": fdc_conf})
+
+    if cut_list is not None:
+        st.register_cut_list(cut_list)
+        
+    write_sr_information_to_config(st, corrections_run_id)
+    return st
 
 
-@URLConfig.register("simulation_config")
-def from_config(config_name, key):
-    """Return a value from a json config file."""
-    config = straxen.get_resource(config_name, fmt="json")
-    return config[key]
-
-
-class DummyMap:
-    """Return constant results with length equal to that of the input and
-    second dimensions (constand correction) user-defined."""
-
-    def __init__(self, const, shape=()):
-        self.const = float(const)
-        self.shape = shape
-
-    def __call__(self, x, **kwargs):
-        shape = [len(x)] + list(self.shape)
-        return np.ones(shape) * self.const
-
-    def reduce_last_dim(self):
-        assert len(self.shape) >= 1, "Need at least 1 dim to reduce further"
-        const = self.const * self.shape[-1]
-        shape = list(self.shape)
-        shape[-1] = 1
-
-        return DummyMap(const, shape)
-
-
-@URLConfig.register("constant_dummy_map")
-def get_dummy(const, shape=()):
-    """Make an Dummy Map."""
-    itp_map = DummyMap(const, shape)
-    return itp_map

--- a/fuse/context.py
+++ b/fuse/context.py
@@ -236,8 +236,11 @@ def full_chain_context(
     # Deregister plugins with missing dependencies
     st.deregister_plugins_with_missing_dependencies()
 
-    # Purge unused configs
-    st.purge_unused_configs()
+    # Purge unused configs (only for newer strax)
+    try:
+        st.purge_unused_configs()
+    except:
+        pass
 
     return st
 

--- a/fuse/context.py
+++ b/fuse/context.py
@@ -20,7 +20,7 @@ if hasattr(straxen.contexts, "xnt_common_opts"):
 else:
     # This is for straxen >=3, variable names changed
     common_opts = straxen.contexts.common_opts
-    common_config = common_config
+    common_config = straxen.contexts.common_config
 
 
 # Plugins to simulate microphysics

--- a/fuse/context_utils.py
+++ b/fuse/context_utils.py
@@ -1,0 +1,130 @@
+import numpy as np
+import strax
+import straxen
+from straxen import URLConfig
+import fuse
+
+def write_sr_information_to_config(context, corrections_run_id):
+    """Function to loop over the plugin config write the cutax sr information
+    to the context config"""
+    for data_type, plugin in context._plugin_class_registry.items():
+        for option_key, option in plugin.takes_config.items():
+            if isinstance(option.default, str) and "science_run://" in option.default:
+                context.config[option_key] = option.default.replace(
+                    "plugin.run_id",
+                    corrections_run_id,
+                )
+
+def old_xedocs_versions_patch(xedocs_version):
+    """
+    To ensure backward compatibility for global version < 15
+    If a user still assigns global_v14 or smaller,
+    the avg_se_gain, g1, and g2 are taken from BODEGA
+    """
+    if int(xedocs_version.replace("global_v", "")) < 15:
+        return {
+            "avg_se_gain": "bodega://se_gain?bodega_version=v1",
+            "g1": "bodega://g1?bodega_version=v5",
+            "g2": "bodega://g2?bodega_version=v5",
+        }
+    else:
+        return {}
+
+
+def set_simulation_config_file(context, config_file_name):
+    """Function to loop over the plugin config and replace
+    SIMULATION_CONFIG_FILE with the actual file name."""
+    for data_type, plugin in context._plugin_class_registry.items():
+        for option_key, option in plugin.takes_config.items():
+            if isinstance(option.default, str) and "SIMULATION_CONFIG_FILE.json" in option.default:
+                context.config[option_key] = option.default.replace(
+                    "SIMULATION_CONFIG_FILE.json", config_file_name
+                )
+
+            # Special case for the photoionization_modifier
+            if option_key == "photoionization_modifier":
+                context.config[option_key] = option.default
+
+
+@URLConfig.register("pattern_map")
+def pattern_map(map_data, pmt_mask, method="WeightedNearestNeighbors"):
+    """Pattern map handling."""
+
+    if "compressed" in map_data:
+        compressor, dtype, shape = map_data["compressed"]
+        map_data["map"] = np.frombuffer(
+            strax.io.COMPRESSORS[compressor]["decompress"](map_data["map"]), dtype=dtype
+        ).reshape(*shape)
+        del map_data["compressed"]
+    if "quantized" in map_data:
+        map_data["map"] = map_data["quantized"] * map_data["map"].astype(np.float32)
+        del map_data["quantized"]
+    if not (pmt_mask is None):
+        assert (
+            map_data["map"].shape[-1] == pmt_mask.shape[0]
+        ), "Error! Pattern map and PMT gains must have same dimensions!"
+        map_data["map"][..., ~pmt_mask] = 0.0
+    return straxen.InterpolatingMap(map_data, method=method)
+
+
+@URLConfig.register("s2_aft_scaling")
+def modify_s2_pattern_map(
+    s2_pattern_map, s2_mean_area_fraction_top, n_tpc_pmts, n_top_pmts, turned_off_pmts
+):
+    """Modify the S2 pattern map to match a given input AFT."""
+    if s2_mean_area_fraction_top > 0:
+        s2map = deepcopy(s2_pattern_map)
+        # First we need to set turned off pmts before scaling
+        s2map.data["map"][..., turned_off_pmts] = 0
+        s2map_topeff_ = s2map.data["map"][..., :n_top_pmts].sum(axis=2, keepdims=True)
+        s2map_toteff_ = s2map.data["map"].sum(axis=2, keepdims=True)
+        orig_aft_ = np.nanmean(s2map_topeff_ / s2map_toteff_)
+        # Getting scales for top/bottom separately to preserve total efficiency
+        scale_top_ = s2_mean_area_fraction_top / orig_aft_
+        scale_bot_ = (1 - s2_mean_area_fraction_top) / (1 - orig_aft_)
+        s2map.data["map"][..., :n_top_pmts] *= scale_top_
+        s2map.data["map"][..., n_top_pmts:n_tpc_pmts] *= scale_bot_
+        s2_pattern_map.__init__(s2map.data)
+    return s2_pattern_map
+
+
+# Probably not needed!
+@URLConfig.register("simple_load")
+def load(data):
+    """Some Documentation."""
+    return data
+
+
+@URLConfig.register("simulation_config")
+def from_config(config_name, key):
+    """Return a value from a json config file."""
+    config = straxen.get_resource(config_name, fmt="json")
+    return config[key]
+
+
+class DummyMap:
+    """Return constant results with length equal to that of the input and
+    second dimensions (constand correction) user-defined."""
+
+    def __init__(self, const, shape=()):
+        self.const = float(const)
+        self.shape = shape
+
+    def __call__(self, x, **kwargs):
+        shape = [len(x)] + list(self.shape)
+        return np.ones(shape) * self.const
+
+    def reduce_last_dim(self):
+        assert len(self.shape) >= 1, "Need at least 1 dim to reduce further"
+        const = self.const * self.shape[-1]
+        shape = list(self.shape)
+        shape[-1] = 1
+
+        return DummyMap(const, shape)
+
+
+@URLConfig.register("constant_dummy_map")
+def get_dummy(const, shape=()):
+    """Make an Dummy Map."""
+    itp_map = DummyMap(const, shape)
+    return itp_map

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ nestpy = ">=2.0.2"
 numba = ">=0.58.1"
 awkward = ">=2.5.1"
 uproot = ">=5.2.1"
-strax = ">=2.0.5"
-straxen = ">=3.0.3"
+strax = ">=1.6.0"
+straxen = ">=2.2.3"
 utilix = ">=0.11.0"
 
 [build-system]


### PR DESCRIPTION
Proposal to move context definition to fuse. 

For details on the proposal, see [wiki note](https://xe1t-wiki.lngs.infn.it/doku.php?id=cfuselli:restructure_fuse_contexts).