### PR TITLE
Patch cmake version in nestpy

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -48,6 +48,10 @@ jobs:
           cd nestpy
           git submodule update --init --recursive
           git checkout fb3804e
+
+          # Patch the CMakeLists.txt file to use a newer version of cmake
+          sed -i 's/cmake_minimum_required(VERSION 2.8.12)/cmake_minimum_required(VERSION 3.12)/' CMakeLists.txt
+
           pip install .
           cd ..
           rm -rf nestpy

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -46,13 +46,21 @@ jobs:
           python -m pip install pytest coverage coveralls
           git clone https://github.com/NESTCollaboration/nestpy.git
           cd nestpy
-          git submodule update --init --recursive
           git checkout fb3804e
+          git submodule update --init --recursive
 
-          # Patch the CMakeLists.txt file to use a newer version of cmake
-          sed -i 's/cmake_minimum_required(VERSION 2.8.12)/cmake_minimum_required(VERSION 3.12)/' CMakeLists.txt
-          sed -i 's/cmake_minimum_required(VERSION 2.8.12)/cmake_minimum_required(VERSION 3.12)/' lib/pybind11/CMakeLists.txt
+          echo "Installing pybind11 and patching cmake version in nestpy"
 
+          # Fix pybind11: use newer tag that works with modern CMake
+          cd lib/pybind11
+          git fetch --tags
+          git checkout v2.13.0
+          cd ../../
+
+          # Fix nestpy's CMakeLists.txt to work with modern CMake versions
+          sed -i 's/cmake_minimum_required(VERSION 2.8.12)/cmake_minimum_required(VERSION 2.8.12...3.30)/' CMakeLists.txt
+
+          # Install
           pip install .
           cd ..
           rm -rf nestpy

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,6 +51,7 @@ jobs:
 
           # Patch the CMakeLists.txt file to use a newer version of cmake
           sed -i 's/cmake_minimum_required(VERSION 2.8.12)/cmake_minimum_required(VERSION 3.12)/' CMakeLists.txt
+          sed -i 's/cmake_minimum_required(VERSION 2.8.12)/cmake_minimum_required(VERSION 3.12)/' lib/pybind11/CMakeLists.txt
 
           pip install .
           cd ..


### PR DESCRIPTION
All fuse tests fail now because of a problem with cmake . 
Probably due to a change in github actions cmake version (see [here](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required)).


With this PR we patch the pybind version to v2.13.0 and change the cmake_minimum_required(VERSION 2.8.12...3.30) in the nestpy cmake list. 

See also https://github.com/NESTCollaboration/nestpy/issues/113