### PR TITLE
Clip FDC input positions

### DIFF
--- a/fuse/plugins/detector_physics/electron_drift.py
+++ b/fuse/plugins/detector_physics/electron_drift.py
@@ -342,7 +342,8 @@ class ElectronDrift(FuseBasePlugin):
         )
         if n_clipped_r > 0 or n_clipped_z > 0:
             self.log.warning(
-                f"Field distortion map is clipped {n_clipped_r} times in r and {n_clipped_z} times in z"
+                f"Field distortion map is clipped {n_clipped_r} \
+                    times in r and {n_clipped_z} times in z"
             )
 
         r_obs = self.fdc_map_fuse(clipped_positions, map_name="r_distortion_map")

--- a/fuse/plugins/detector_physics/electron_drift.py
+++ b/fuse/plugins/detector_physics/electron_drift.py
@@ -215,6 +215,15 @@ class ElectronDrift(FuseBasePlugin):
 
             self.diffusion_longitudinal_map = _rz_map
 
+
+
+        csys = self.fdc_map_fuse.coordinate_system
+        rmin, rmax = csys[:, 0].min(), csys[:, 0].max()
+        zmin, zmax = csys[:, 1].min(), csys[:, 1].max()
+        self.fdc_map_r_bounds = (rmin, rmax)
+        self.fdc_map_z_bounds = (zmin, zmax)
+
+
     def compute(self, interactions_in_roi):
         # Just apply this to clusters with photons
         mask = interactions_in_roi["electrons"] > 0
@@ -317,7 +326,16 @@ class ElectronDrift(FuseBasePlugin):
         """
         positions = np.array([np.sqrt(x**2 + y**2), z]).T
         theta = np.arctan2(y, x)
-        r_obs = self.fdc_map_fuse(positions, map_name="r_distortion_map")
+
+        clipped_positions = np.copy(positions)
+        clipped_positions[:, 0] = np.clip(
+            clipped_positions[:, 0], self.fdc_map_r_bounds[0], self.fdc_map_r_bounds[1]
+        )
+        clipped_positions[:, 1] = np.clip(
+            clipped_positions[:, 1], self.fdc_map_z_bounds[0], self.fdc_map_z_bounds[1]
+        )
+
+        r_obs = self.fdc_map_fuse(clipped_positions, map_name="r_distortion_map")
         x_obs = r_obs * np.cos(theta)
         y_obs = r_obs * np.sin(theta)
 

--- a/fuse/plugins/detector_physics/electron_drift.py
+++ b/fuse/plugins/detector_physics/electron_drift.py
@@ -215,14 +215,11 @@ class ElectronDrift(FuseBasePlugin):
 
             self.diffusion_longitudinal_map = _rz_map
 
-
-
         csys = self.fdc_map_fuse.coordinate_system
         rmin, rmax = csys[:, 0].min(), csys[:, 0].max()
         zmin, zmax = csys[:, 1].min(), csys[:, 1].max()
         self.fdc_map_r_bounds = (rmin, rmax)
         self.fdc_map_z_bounds = (zmin, zmax)
-
 
     def compute(self, interactions_in_roi):
         # Just apply this to clusters with photons

--- a/fuse/plugins/detector_physics/electron_drift.py
+++ b/fuse/plugins/detector_physics/electron_drift.py
@@ -332,6 +332,19 @@ class ElectronDrift(FuseBasePlugin):
             clipped_positions[:, 1], self.fdc_map_z_bounds[0], self.fdc_map_z_bounds[1]
         )
 
+        n_clipped_r = np.sum(
+            (positions[:, 0] < self.fdc_map_r_bounds[0])
+            | (positions[:, 0] > self.fdc_map_r_bounds[1])
+        )
+        n_clipped_z = np.sum(
+            (positions[:, 1] < self.fdc_map_z_bounds[0])
+            | (positions[:, 1] > self.fdc_map_z_bounds[1])
+        )
+        if n_clipped_r > 0 or n_clipped_z > 0:
+            self.log.warning(
+                f"Field distortion map is clipped {n_clipped_r} times in r and {n_clipped_z} times in z"
+            )
+
         r_obs = self.fdc_map_fuse(clipped_positions, map_name="r_distortion_map")
         x_obs = r_obs * np.cos(theta)
         y_obs = r_obs * np.sin(theta)


### PR DESCRIPTION
This PR is an alternative solution to #296.

As suggested by @sebvetter , a better solution than hardcoding the value of Z for the FDC map boundaries as in #296 , here we clip the positions that we pass to the map to the boundaries of the validity of the map (that we get from the map coordinate system). 

The results seem to give the required behaviour, here comparing clipped vs unclipped DeltaR as a function of Z, for a given R. 

![output_r0](https://github.com/user-attachments/assets/ab12a294-62eb-44cf-84f8-bed287594b89)
![output_r20](https://github.com/user-attachments/assets/ed63d3e4-da37-4435-8ff6-c6c32c58dd67)
![output_r60](https://github.com/user-attachments/assets/e523e3aa-d423-4b61-8b48-cd763abb13a8)

 