### PR TITLE
MC override in context config

### DIFF
--- a/fuse/context.py
+++ b/fuse/context.py
@@ -324,7 +324,7 @@ def xenonnt_fuse_full_chain_simulation(
     st.set_config({"fdc_map": fdc_conf})
 
     # Overwrite some resource files with the ones from the simulation config
-    apply_mc_overrides(st, corrections_version)
+    apply_mc_overrides(st, simulation_config_file)
 
     if cut_list is not None:
         st.register_cut_list(cut_list)

--- a/fuse/context_utils.py
+++ b/fuse/context_utils.py
@@ -173,9 +173,7 @@ def lce_from_pattern_map(map, pmt_mask):
 
 
 def apply_mc_overrides(context, config_file):
-    """
-    Apply config overrides from 'mc_overrides' using from_config.
-    """
+    """Apply config overrides from 'mc_overrides' using from_config."""
     try:
         config = straxen.get_resource(config_file, fmt="json")
         overrides = config.get("mc_overrides", {})
@@ -188,6 +186,4 @@ def apply_mc_overrides(context, config_file):
             context.set_config({key: url})
             log.debug(f"[mc_overrides] Set '{key}' to '{value}'")
     except Exception as e:
-        raise ValueError(
-            f"[mc_overrides] Failed to apply overrides from {config_file}: {e}"
-        ) from e
+        raise ValueError(f"[mc_overrides] Failed to apply overrides from {config_file}: {e}") from e

--- a/fuse/context_utils.py
+++ b/fuse/context_utils.py
@@ -166,3 +166,21 @@ def lce_from_pattern_map(map, pmt_mask):
     lcemap.data["map"] = np.sum(lcemap.data["map"][:][:][:], axis=3, keepdims=True, where=pmt_mask)
     lcemap.__init__(lcemap.data)
     return lcemap
+
+
+def apply_mc_overrides(context, config_file):
+    """
+    Apply config overrides from 'mc_overrides' using fuse.from_config.
+    """
+    try:
+        overrides = fuse.from_config(config_file, "mc_overrides")
+        for key, value in overrides.items():
+            if isinstance(value, list) and len(value) == 2:
+                filename, template = value
+                url = template.replace("MAP_NAME", filename)
+            else:
+                url = value
+            context.set_config({key: url})
+            log.debug(f"[mc_overrides] Set '{key}' to '{value}'")
+    except Exception as e:
+        log.warning(f"[mc_overrides] Failed to apply overrides from {config_file}: {e}")

--- a/fuse/context_utils.py
+++ b/fuse/context_utils.py
@@ -3,6 +3,10 @@ import strax
 import straxen
 from straxen import URLConfig
 from copy import deepcopy
+import logging
+
+logging.basicConfig(handlers=[logging.StreamHandler()])
+log = logging.getLogger("fuse.context_utils")
 
 
 def write_sr_information_to_config(context, corrections_run_id):
@@ -170,10 +174,10 @@ def lce_from_pattern_map(map, pmt_mask):
 
 def apply_mc_overrides(context, config_file):
     """
-    Apply config overrides from 'mc_overrides' using fuse.from_config.
+    Apply config overrides from 'mc_overrides' using from_config.
     """
     try:
-        overrides = fuse.from_config(config_file, "mc_overrides")
+        overrides = from_config(config_file, "mc_overrides")
         for key, value in overrides.items():
             if isinstance(value, list) and len(value) == 2:
                 filename, template = value

--- a/fuse/context_utils.py
+++ b/fuse/context_utils.py
@@ -177,7 +177,8 @@ def apply_mc_overrides(context, config_file):
     Apply config overrides from 'mc_overrides' using from_config.
     """
     try:
-        overrides = from_config(config_file, "mc_overrides")
+        config = straxen.get_resource(config_file, fmt="json")
+        overrides = config.get("mc_overrides", {})
         for key, value in overrides.items():
             if isinstance(value, list) and len(value) == 2:
                 filename, template = value
@@ -187,4 +188,6 @@ def apply_mc_overrides(context, config_file):
             context.set_config({key: url})
             log.debug(f"[mc_overrides] Set '{key}' to '{value}'")
     except Exception as e:
-        log.warning(f"[mc_overrides] Failed to apply overrides from {config_file}: {e}")
+        raise ValueError(
+            f"[mc_overrides] Failed to apply overrides from {config_file}: {e}"
+        ) from e


### PR DESCRIPTION
Allow flexible overwrite of straxen configs from fuse config file. 

I will remove the fdc_map_mc from the new config format, and leave the old way of treating the fdc map in the fuse context.
In this way the new fuse version would be compatible with both newer and older config files, but old fuse versions not compatible with new config file (potentially dangerous as it would ignore the overwrite).


Supports formats like: 

```
"mc_overrides": {
  "s1_xyz_map": ["XnT_S1_xyz_123.json", "itp_map://resource://MAP_NAME?fmt=json"]
  "fdc_map": "itp_map://resource://XnT_S1_xyz_123.json?fmt=json"]
}

```
in the config file, as in https://github.com/XENONnT/private_nt_aux_files/pull/424. 