### PR TITLE
Fix context to be compatible with new config formats

### DIFF
--- a/fuse/context.py
+++ b/fuse/context.py
@@ -323,7 +323,7 @@ def xenonnt_fuse_full_chain_simulation(
     else:
         # Backward compatibility: legacy fdc_map_mc logic
         if "fdc_map_mc" in config:
-            fdc_map_mc = fdc_map_mc or config["fdc_map_mc"]
+            fdc_map_mc = config["fdc_map_mc"]
             log.info(f"[legacy] Using fdc_map_mc: {fdc_map_mc}")
             fdc_ext = fdc_map_mc.split(fdc_map_mc.split(".")[0] + ".")[-1]
             fdc_conf = f"itp_map://resource://{fdc_map_mc}?fmt={fdc_ext}"


### PR DESCRIPTION
With #308 I introduced a new context to be compatible both with old and new configs.
It should have supported, for example, setting the fdc_map both with fdc_map_mc or mc_overrides.
But the logic was wrong so the fdc_map_mc was still required, making the new context not usable. 
Now this should be fixed in this PR, so we can still use both formats. 