### PR TITLE
Print warning message properly

### DIFF
--- a/fuse/plugins/detector_physics/electron_drift.py
+++ b/fuse/plugins/detector_physics/electron_drift.py
@@ -342,8 +342,8 @@ class ElectronDrift(FuseBasePlugin):
         )
         if n_clipped_r > 0 or n_clipped_z > 0:
             self.log.warning(
-                f"Field distortion map is clipped {n_clipped_r} \
-                    times in r and {n_clipped_z} times in z"
+                "Field distortion map is clipped "
+                f"{n_clipped_r} times in r and {n_clipped_z} times in z"
             )
 
         r_obs = self.fdc_map_fuse(clipped_positions, map_name="r_distortion_map")


### PR DESCRIPTION
_Before you submit this PR: make sure to put all XENONnT specific information in a wiki-note as the repo is publicly accessible_

## What does the code in this PR do / what does it improve?

Because sometimes I see

```
WARNING:ElectronDrift:Field distortion map is clipped 107                     times in r and 535 times in z
```

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Bump plugin version(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
