### PR TITLE
fix positrons cluster classification in MergeCluster.classify

### DIFF
--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -402,8 +402,8 @@ def classify_lineage(particle_interaction, classify_ic_as_gamma, classify_phot_a
             # This case should not happen or? Classify it as nontype
             return NEST_NONE
 
-    # Electrons that are not created by a gamma.
-    elif particle_interaction["type"] == "e-":
+    # Electrons or positrons that are not created by a gamma.
+    elif (particle_interaction["type"] == "e-") | (particle_interaction["type"] == "e+"):
         return NEST_BETA
 
     # The gamma case

--- a/fuse/plugins/micro_physics/merge_cluster.py
+++ b/fuse/plugins/micro_physics/merge_cluster.py
@@ -125,7 +125,7 @@ def classify(types, parenttype, creaproc, edproc):
         return infinity, 0, 11
     elif types == "gamma":
         return 0, 0, 7
-    elif types == "e-":
+    elif (types == "e-")|(types == "e+"):
         return 0, 0, 8
     else:
         return infinity, infinity, 12

--- a/fuse/plugins/micro_physics/merge_cluster.py
+++ b/fuse/plugins/micro_physics/merge_cluster.py
@@ -125,7 +125,7 @@ def classify(types, parenttype, creaproc, edproc):
         return infinity, 0, 11
     elif types == "gamma":
         return 0, 0, 7
-    elif (types == "e-")|(types == "e+"):
+    elif (types == "e-") | (types == "e+"):
         return 0, 0, 8
     else:
         return infinity, infinity, 12


### PR DESCRIPTION
Positrons were mistakenly classified as `'nontype'`.
Modified a line to classify `'e+'` to be beta-like.