### PR TITLE
Skip aft correction for fuse? 

### DIFF
--- a/fuse/plugins/processing/corrected_areas.py
+++ b/fuse/plugins/processing/corrected_areas.py
@@ -39,9 +39,9 @@ class CorrectedAreasMC(straxen.CorrectedAreas):
 
         if not self.enable_delayed_electrons:
             for peak_type in ["", "alt_"]:            
-                result[f"{peak_type}cs2_area_fraction_top"] = result["s2_area_fraction_top"]
-                result[f"{peak_type}cs2_area_fraction_top_wo_timecorr"] = result["s2_area_fraction_top"]
-                result[f"{peak_type}cs2_area_fraction_top_wo_elifecorr"] = result["s2_area_fraction_top"]
-                result[f"{peak_type}cs2_area_fraction_top_wo_picorr"] = result["s2_area_fraction_top"]
+                result[f"{peak_type}cs2_area_fraction_top"] = events["s2_area_fraction_top"]
+                result[f"{peak_type}cs2_area_fraction_top_wo_timecorr"] = events["s2_area_fraction_top"]
+                result[f"{peak_type}cs2_area_fraction_top_wo_elifecorr"] = events["s2_area_fraction_top"]
+                result[f"{peak_type}cs2_area_fraction_top_wo_picorr"] = events["s2_area_fraction_top"]
 
         return result

--- a/fuse/plugins/processing/corrected_areas.py
+++ b/fuse/plugins/processing/corrected_areas.py
@@ -27,12 +27,7 @@ class CorrectedAreasMC(straxen.CorrectedAreas):
         track=True,
         help="Decide if you want to to enable delayed electrons from photoionization",
     )
-    
-    def setup(self):
-        super().setup()
 
-        if not self.enable_delayed_electrons:
-            self.cs2_bottom_top_ratio_correction = 1
         
     def compute(self, events):
         result = super().compute(events)
@@ -41,5 +36,12 @@ class CorrectedAreasMC(straxen.CorrectedAreas):
 
         result["alt_cs1"] = result["alt_cs1_wo_timecorr"]
         result["alt_cs2"] = result["alt_cs2_wo_timecorr"]
+
+        if not self.enable_delayed_electrons:
+            for peak_type in ["", "alt_"]:            
+                result[f"{peak_type}cs2_area_fraction_top"] = result["s2_area_fraction_top"]
+                result[f"{peak_type}cs2_area_fraction_top_wo_timecorr"] = result["s2_area_fraction_top"]
+                result[f"{peak_type}cs2_area_fraction_top_wo_elifecorr"] = result["s2_area_fraction_top"]
+                result[f"{peak_type}cs2_area_fraction_top_wo_picorr"] = result["s2_area_fraction_top"]
 
         return result

--- a/fuse/plugins/processing/corrected_areas.py
+++ b/fuse/plugins/processing/corrected_areas.py
@@ -21,6 +21,19 @@ class CorrectedAreasMC(straxen.CorrectedAreas):
     __version__ = "0.0.1"
     child_plugin = True
 
+    enable_delayed_electrons = straxen.URLConfig(
+        default=False,
+        type=bool,
+        track=True,
+        help="Decide if you want to to enable delayed electrons from photoionization",
+    )
+    
+    def setup(self):
+        super().setup()
+
+        if not self.enable_delayed_electrons:
+            self.cs2_bottom_top_ratio_correction = 1
+        
     def compute(self, events):
         result = super().compute(events)
         result["cs1"] = result["cs1_wo_timecorr"]

--- a/fuse/plugins/processing/corrected_areas.py
+++ b/fuse/plugins/processing/corrected_areas.py
@@ -18,7 +18,7 @@ class CorrectedAreasMC(straxen.CorrectedAreas):
     data!
     """
 
-    __version__ = "0.0.1"
+    __version__ = "0.0.2"
     child_plugin = True
 
     enable_delayed_electrons = straxen.URLConfig(

--- a/fuse/plugins/processing/corrected_areas.py
+++ b/fuse/plugins/processing/corrected_areas.py
@@ -28,7 +28,6 @@ class CorrectedAreasMC(straxen.CorrectedAreas):
         help="Decide if you want to to enable delayed electrons from photoionization",
     )
 
-        
     def compute(self, events):
         result = super().compute(events)
         result["cs1"] = result["cs1_wo_timecorr"]
@@ -38,10 +37,16 @@ class CorrectedAreasMC(straxen.CorrectedAreas):
         result["alt_cs2"] = result["alt_cs2_wo_timecorr"]
 
         if not self.enable_delayed_electrons:
-            for peak_type in ["", "alt_"]:            
+            for peak_type in ["", "alt_"]:
                 result[f"{peak_type}cs2_area_fraction_top"] = events["s2_area_fraction_top"]
-                result[f"{peak_type}cs2_area_fraction_top_wo_timecorr"] = events["s2_area_fraction_top"]
-                result[f"{peak_type}cs2_area_fraction_top_wo_elifecorr"] = events["s2_area_fraction_top"]
-                result[f"{peak_type}cs2_area_fraction_top_wo_picorr"] = events["s2_area_fraction_top"]
+                result[f"{peak_type}cs2_area_fraction_top_wo_timecorr"] = events[
+                    "s2_area_fraction_top"
+                ]
+                result[f"{peak_type}cs2_area_fraction_top_wo_elifecorr"] = events[
+                    "s2_area_fraction_top"
+                ]
+                result[f"{peak_type}cs2_area_fraction_top_wo_picorr"] = events[
+                    "s2_area_fraction_top"
+                ]
 
         return result


### PR DESCRIPTION
At lease if we do not simulate PI, do not correct AFT for PI effect.

Not sure if this is the best way to do it.  