### PR TITLE
Allow None `corrections_run_id`

### DIFF
--- a/fuse/context.py
+++ b/fuse/context.py
@@ -144,6 +144,7 @@ def full_chain_context(
         "drift_time_gate": "electron_drift_time_gate",
     },
     run_without_proper_corrections=False,
+    run_without_proper_run_id=False,
     clustering_method="dbscan",
     extra_plugins=[],
 ):
@@ -152,6 +153,12 @@ def full_chain_context(
     # Lets go for info level logging when working with fuse
     log.setLevel("INFO")
 
+    if (corrections_run_id is None) & (not run_without_proper_run_id):
+        raise ValueError(
+            "Specify a corrections_run_id. If you want to run without proper "
+            "run_id for testing or just trying out fuse, "
+            "set run_without_proper_run_id to True"
+        )
     if (corrections_version is None) & (not run_without_proper_corrections):
         raise ValueError(
             "Specify a corrections_version. If you want to run without proper "
@@ -229,7 +236,7 @@ def full_chain_context(
 
     set_simulation_config_file(st, simulation_config_file)
 
-    if not run_without_proper_corrections:
+    if not run_without_proper_run_id:
         write_run_id_to_config(st, corrections_run_id)
         write_sr_information_to_config(st, corrections_run_id)
 
@@ -259,6 +266,7 @@ def xenonnt_fuse_full_chain_simulation(
     simulation_config=DEFAULT_SIMULATION_VERSION,
     corrections_run_id=None,
     run_without_proper_corrections=False,
+    run_without_proper_run_id=False,
     clustering_method=None,  # defaults to dbscan, but can be set to lineage
     cut_list=None,
     **kwargs,
@@ -282,7 +290,7 @@ def xenonnt_fuse_full_chain_simulation(
     log.info(f"Using simulation config file: {simulation_config_file}")
 
     # Get the corrections_run_id from argument or from config file
-    if not run_without_proper_corrections:
+    if not run_without_proper_run_id:
         corrections_run_id = corrections_run_id or fuse.from_config(
             simulation_config_file, "default_corrections_run_id"
         )
@@ -304,7 +312,7 @@ def xenonnt_fuse_full_chain_simulation(
         corrections_version=corrections_version,
         simulation_config_file=simulation_config_file,
         corrections_run_id=corrections_run_id,
-        run_without_proper_corrections=run_without_proper_corrections,
+        run_without_proper_run_id=run_without_proper_run_id,
         clustering_method=clustering_method,
         **kwargs,
     )

--- a/fuse/context.py
+++ b/fuse/context.py
@@ -265,7 +265,6 @@ def xenonnt_fuse_full_chain_simulation(
     corrections_version=DEFAULT_XEDOCS_VERSION,
     simulation_config=DEFAULT_SIMULATION_VERSION,
     corrections_run_id=None,
-    run_without_proper_corrections=False,
     run_without_proper_run_id=False,
     clustering_method=None,  # defaults to dbscan, but can be set to lineage
     cut_list=None,

--- a/fuse/context.py
+++ b/fuse/context.py
@@ -248,7 +248,7 @@ def full_chain_context(
             print(f"Warning! {processing_config} not in context config, skipping...")
 
     # No blinding in simulations
-    st.config["event_info_function"] = "disabled"
+    st.set_config({"event_info_function": "disabled"})
 
     # Deregister plugins with missing dependencies
     st.deregister_plugins_with_missing_dependencies()
@@ -422,7 +422,7 @@ def public_config_context(
     )
 
     # No blinding in simulations
-    st.config["event_info_function"] = "disabled"
+    st.set_config({"event_info_function": "disabled"})
 
     # Deregister plugins with missing dependencies
     st.deregister_plugins_with_missing_dependencies()

--- a/fuse/context.py
+++ b/fuse/context.py
@@ -7,6 +7,7 @@ import fuse
 
 from .context_utils import (
     write_sr_information_to_config,
+    write_run_id_to_config,
     set_simulation_config_file,
     old_xedocs_versions_patch,
     overwrite_map_from_config,
@@ -230,14 +231,7 @@ def full_chain_context(
 
     set_simulation_config_file(st, simulation_config_file)
 
-    local_versions = st.config
-    for config_name, url_config in local_versions.items():
-        if isinstance(url_config, str):
-            if "run_id" in url_config:
-                local_versions[config_name] = straxen.URLConfig.format_url_kwargs(
-                    url_config, run_id=corrections_run_id
-                )
-    st.config = local_versions
+    write_run_id_to_config(st, corrections_run_id)
 
     # Update some run specific config
     for mc_config, processing_config in run_id_specific_config.items():

--- a/fuse/context.py
+++ b/fuse/context.py
@@ -6,7 +6,6 @@ import straxen
 import fuse
 
 from .context_utils import (
-    write_sr_information_to_config,
     write_run_id_to_config,
     set_simulation_config_file,
     old_xedocs_versions_patch,
@@ -238,7 +237,6 @@ def full_chain_context(
 
     if not run_without_proper_run_id:
         write_run_id_to_config(st, corrections_run_id)
-        write_sr_information_to_config(st, corrections_run_id)
 
     # Update some run specific config
     for mc_config, processing_config in run_id_specific_config.items():

--- a/fuse/context_utils.py
+++ b/fuse/context_utils.py
@@ -11,7 +11,7 @@ log = logging.getLogger("fuse.context_utils")
 
 def write_sr_information_to_config(context, corrections_run_id):
     """Function to loop over the plugin config write the cutax sr information
-    to the context config."""
+    to the context config by assigning run_id."""
     for data_type, plugin in context._plugin_class_registry.items():
         for option_key, option in plugin.takes_config.items():
             if isinstance(option.default, str) and "science_run://" in option.default:
@@ -19,6 +19,19 @@ def write_sr_information_to_config(context, corrections_run_id):
                     "plugin.run_id",
                     corrections_run_id,
                 )
+
+
+def write_run_id_to_config(context, corrections_run_id):
+    """Function to loop over the plugin config write run_id."""
+    for config_name, url_config in deepcopy(context.config).items():
+        if isinstance(url_config, str) and "run_id" in url_config:
+            context.set_config(
+                {
+                    config_name: straxen.URLConfig.format_url_kwargs(
+                        url_config, run_id=corrections_run_id
+                    )
+                }
+            )
 
 
 def old_xedocs_versions_patch(xedocs_version):


### PR DESCRIPTION
_Before you submit this PR: make sure to put all XENONnT specific information in a wiki-note as the repo is publicly accessible_

## What does the code in this PR do / what does it improve?

This PR confines the code for writing `run_id` into lineage within a single function, `write_run_id_to_config`.

The PR allows `corrections_run_id` to be None, by setting `run_without_proper_run_id=True`.

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [x] _Update the docstring(s)_
  - [ ] _Bump plugin version(s)_
  - [ ] _Update the documentation_
  - [x] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
