### PR TITLE
Fix lineage_cluster ids

### DIFF
--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -104,7 +104,7 @@ class LineageClustering(FuseBasePlugin):
         )
 
         data = np.zeros(len(geant4_interactions), dtype=self.dtype)
-        data["lineage_index"] = unique_lineage_index
+        data["lineage_index"] = unique_lineage_index + self.lineages_build
         data["event_lineage_index"] = lineage_ids
         data["lineage_type"] = lineage_types
         data["A"] = lineage_A
@@ -113,6 +113,8 @@ class LineageClustering(FuseBasePlugin):
 
         data["time"] = geant4_interactions["time"]
         data["endtime"] = geant4_interactions["endtime"]
+
+        self.lineages_build = np.max(data["lineage_index"]) + 1
 
         return data
 
@@ -145,14 +147,12 @@ class LineageClustering(FuseBasePlugin):
                 self.classify_ic_as_gamma,
                 self.classify_phot_as_beta,
             )[undo_sort_index]
-
-            all_lineag_ids.append(lineage["lineage_index"] + self.lineages_build)
+            
+            all_lineag_ids.append(lineage["lineage_index"])
             all_lineage_types.append(lineage["lineage_type"])
             all_lineage_As.append(lineage["lineage_A"])
             all_lineage_Zs.append(lineage["lineage_Z"])
             all_main_cluster_types.append(lineage["main_cluster_type"])
-
-            self.lineages_build = np.max(lineage["lineage_index"]) + 1
 
         return (
             np.concatenate(all_lineag_ids),


### PR DESCRIPTION
 We found a bug in the lineage cluster plugin that makes the cluster_ids not unique in a run. This is because of a bug in the implementation of the incremental ids, that was resetting at each chunk, so for each chunk the ids were starting from 0 again. 
This should create no issues in the processing of the lineages itself, but it could influence the logic of, for example, truth plugins based on the matching of the cluster id. 

The proposed change should fix this problem making cluster_ids (lineage_index) unique in a run. The same logic is used in the find_cluster.py plugin. 

See plots below for cluster_id as a function of interaction index, before and after this PR: 

Before:
<img width="580" height="455" alt="image (14)" src="https://github.com/user-attachments/assets/b6ee3c38-c68a-4434-8718-15d5aa174487" />
After:
<img width="589" height="455" alt="outputccc" src="https://github.com/user-attachments/assets/efad7386-b534-4826-ba11-36032c0ce06c" />
