### PR TITLE
Add s2_pattern_map_interpolation_method

### DIFF
--- a/fuse/context_utils.py
+++ b/fuse/context_utils.py
@@ -88,7 +88,7 @@ def pattern_map(map_data, pmt_mask, method="WeightedNearestNeighbors"):
         map_data["map"][..., ~pmt_mask] = 0.0
 
     log.debug(f"Interpolating pattern map '{map_data['name']}' with method '{method}'")
-    
+
     return straxen.InterpolatingMap(map_data, method=method)
 
 

--- a/fuse/context_utils.py
+++ b/fuse/context_utils.py
@@ -86,6 +86,9 @@ def pattern_map(map_data, pmt_mask, method="WeightedNearestNeighbors"):
             map_data["map"].shape[-1] == pmt_mask.shape[0]
         ), "Error! Pattern map and PMT gains must have same dimensions!"
         map_data["map"][..., ~pmt_mask] = 0.0
+
+    log.debug(f"Interpolating pattern map '{map_data['name']}' with method '{method}'")
+    
     return straxen.InterpolatingMap(map_data, method=method)
 
 

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -213,7 +213,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
         "&n_tpc_pmts=plugin.n_tpc_pmts"
         "&n_top_pmts=plugin.n_top_pmts"
         "&turned_off_pmts=plugin.turned_off_pmts"
-        "&s2_pattern_map_interpolation_method=plugin.s2_pattern_map_interpolation_method",
+        "&method=plugin.s2_pattern_map_interpolation_method",
         cache=True,
         help="S2 pattern map",
     )

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -29,7 +29,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
     Note: The timing calculation is defined in the child plugin.
     """
 
-    __version__ = "0.3.5"
+    __version__ = "0.3.6"
 
     depends_on = (
         "merged_electron_time",
@@ -212,9 +212,17 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
         "&s2_mean_area_fraction_top=plugin.s2_mean_area_fraction_top"
         "&n_tpc_pmts=plugin.n_tpc_pmts"
         "&n_top_pmts=plugin.n_top_pmts"
-        "&turned_off_pmts=plugin.turned_off_pmts",
+        "&turned_off_pmts=plugin.turned_off_pmts"
+        "&s2_pattern_map_interpolation_method=plugin.s2_pattern_map_interpolation_method",
         cache=True,
         help="S2 pattern map",
+    )
+
+    s2_pattern_map_interpolation_method = straxen.URLConfig(
+        default="WeightedNearestNeighbors",
+        help="Interpolation method for the S2 pattern map",
+        type=str,
+        cache=True,
     )
 
     singlet_fraction_gas = straxen.URLConfig(


### PR DESCRIPTION
We want to be able to define the interpolation method of the s2 pattern map. 
We leave as default the `WeightedNearestNeighbors`. 
We will change it accordingly in the simulation config files using the mc_overrides key. 