### PR TITLE
Use stable `sort` and `argsort` to avoid indeterministic result

### DIFF
--- a/fuse/common.py
+++ b/fuse/common.py
@@ -28,8 +28,8 @@ kind_colors = dict(
 
 @numba.njit()
 def dynamic_chunking(data, scale, n_min):
-    idx_sort = np.argsort(data)
-    idx_undo_sort = np.argsort(idx_sort)
+    idx_sort = stable_argsort(data)
+    idx_undo_sort = stable_argsort(idx_sort)
 
     data_sorted = data[idx_sort]
 

--- a/fuse/plugins/detector_physics/csv_input.py
+++ b/fuse/plugins/detector_physics/csv_input.py
@@ -12,7 +12,7 @@ from ...dtypes import (
     quanta_fields,
     electric_fields,
 )
-from ...common import dynamic_chunking
+from ...common import stable_sort, stable_argsort, dynamic_chunking
 from ...plugin import FuseBasePlugin
 
 export, __all__ = strax.exporter()
@@ -173,7 +173,7 @@ class csv_file_loader:
             event_times = self.rng.uniform(
                 low=0, high=n_simulated_events / self.event_rate, size=n_simulated_events
             ).astype(np.int64)
-            event_times = np.sort(event_times)
+            event_times = stable_sort(event_times)
 
             structure = np.unique(instructions["eventid"], return_counts=True)[1]
             interaction_time = np.repeat(event_times[: len(structure)], structure)
@@ -184,7 +184,7 @@ class csv_file_loader:
         else:
             raise ValueError("Source rate cannot be negative!")
 
-        sort_idx = np.argsort(instructions["time"])
+        sort_idx = stable_argsort(instructions["time"])
         instructions = instructions[sort_idx]
 
         # Group into chunks

--- a/fuse/plugins/detector_physics/delayed_electrons/photo_ionization_electrons.py
+++ b/fuse/plugins/detector_physics/delayed_electrons/photo_ionization_electrons.py
@@ -3,6 +3,7 @@ import straxen
 import numpy as np
 from scipy.stats import expon, truncexpon
 
+from ....common import stable_argsort
 from ....plugin import FuseBasePlugin
 
 export, __all__ = strax.exporter()
@@ -256,7 +257,7 @@ def ramdom_xy_position(n, radius, rng):
 def group_electrons_by_cluster_id(electrons):
     """Function to group electrons by cluster_id."""
 
-    sort_index = np.argsort(electrons["cluster_id"])
+    sort_index = stable_argsort(electrons["cluster_id"])
 
     electrons_sorted = electrons[sort_index]
 

--- a/fuse/plugins/detector_physics/s1_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s1_photon_propagation.py
@@ -4,8 +4,10 @@ import strax
 import straxen
 
 from ...dtypes import propagated_photons_fields
-from ...common import pmt_gains, build_photon_propagation_output
 from ...common import (
+    stable_argsort,
+    pmt_gains,
+    build_photon_propagation_output,
     init_spe_scaling_factor_distributions,
     pmt_transit_time_spread,
     photon_gain_calculation,
@@ -197,7 +199,7 @@ class S1PhotonPropagationBase(FuseBasePlugin):
         )
 
         # I should sort by time i guess
-        sortind = np.argsort(_photon_timings)
+        sortind = stable_argsort(_photon_timings)
         _photon_channels = _photon_channels[sortind]
         _photon_timings = _photon_timings[sortind]
         _cluster_id = _cluster_id[sortind]

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -7,8 +7,10 @@ from scipy.stats import skewnorm
 from scipy import constants
 
 from ...dtypes import propagated_photons_fields
-from ...common import pmt_gains, build_photon_propagation_output
 from ...common import (
+    stable_argsort,
+    pmt_gains,
+    build_photon_propagation_output,
     init_spe_scaling_factor_distributions,
     pmt_transit_time_spread,
     photon_gain_calculation,
@@ -374,8 +376,8 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
 
         # Sort both the interactions and the electrons by cluster_id
         # We will later sort by time again when yielding the data.
-        sort_index_ic = np.argsort(interactions_chunk["cluster_id"])
-        sort_index_eg = np.argsort(electron_group["cluster_id"])
+        sort_index_ic = stable_argsort(interactions_chunk["cluster_id"])
+        sort_index_eg = stable_argsort(electron_group["cluster_id"])
         interactions_chunk = interactions_chunk[sort_index_ic]
         electron_group = electron_group[sort_index_eg]
 

--- a/fuse/plugins/detector_physics/secondary_scintillation.py
+++ b/fuse/plugins/detector_physics/secondary_scintillation.py
@@ -4,7 +4,7 @@ import numpy as np
 import strax
 import straxen
 
-from ...common import pmt_gains
+from ...common import stable_argsort, pmt_gains
 from ...plugin import FuseBasePlugin
 
 export, __all__ = strax.exporter()
@@ -234,7 +234,7 @@ class SecondaryScintillation(FuseBasePlugin):
 def group_result_photons_by_cluster_id(result, cluster_id):
     """Function to group result_photons by cluster_id."""
 
-    sort_index = np.argsort(cluster_id)
+    sort_index = stable_argsort(cluster_id)
 
     cluster_id_sorted = cluster_id[sort_index]
     result_sorted = result[sort_index]

--- a/fuse/plugins/micro_physics/find_cluster.py
+++ b/fuse/plugins/micro_physics/find_cluster.py
@@ -4,6 +4,7 @@ import strax
 import straxen
 from sklearn.cluster import DBSCAN
 
+from ...common import stable_argsort
 from ...plugin import FuseBasePlugin
 
 export, __all__ = strax.exporter()
@@ -127,8 +128,8 @@ def simple_1d_clustering(data, scale):
         clusters_undo_sort (np.array): Cluster Labels
     """
 
-    idx_sort = np.argsort(data)
-    idx_undo_sort = np.argsort(idx_sort)
+    idx_sort = stable_argsort(data)
+    idx_undo_sort = stable_argsort(idx_sort)
 
     data_sorted = data[idx_sort]
 

--- a/fuse/plugins/micro_physics/input.py
+++ b/fuse/plugins/micro_physics/input.py
@@ -9,7 +9,14 @@ import strax
 import straxen
 
 from ...dtypes import g4_fields, primary_positions_fields, deposit_positions_fields
-from ...common import full_array_to_numpy, reshape_awkward, dynamic_chunking, awkward_to_flat_numpy
+from ...common import (
+    stable_sort,
+    stable_argsort,
+    full_array_to_numpy,
+    reshape_awkward,
+    dynamic_chunking,
+    awkward_to_flat_numpy,
+)
 from ...plugin import FuseBasePlugin
 
 export, __all__ = strax.exporter()
@@ -286,7 +293,7 @@ class file_loader:
                 event_times = self.rng.uniform(
                     low=start / self.event_rate, high=stop / self.event_rate, size=num_interactions
                 ).astype(np.int64)
-                event_times = np.sort(event_times)
+                event_times = stable_sort(event_times)
 
             interactions["time"] = interactions["t"] + event_times
 
@@ -309,7 +316,7 @@ class file_loader:
         interaction_time = awkward_to_flat_numpy(interactions["time"])
 
         # First caclulate sort index for the interaction times
-        sort_idx = np.argsort(interaction_time)
+        sort_idx = stable_argsort(interaction_time)
         # and now make it an integer for strax time field
         interaction_time = interaction_time.astype(np.int64)
         # Sort the interaction times
@@ -376,7 +383,7 @@ class file_loader:
             current_chunk = current_chunk[select_times]
 
             # Sorting each chunk by time within the chunk
-            sort_chunk = np.argsort(current_chunk["time"])
+            sort_chunk = stable_argsort(current_chunk["time"])
             current_chunk = current_chunk[sort_chunk]
 
             if c_ix == unique_chunk_index_values[-1]:

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -5,6 +5,7 @@ import straxen
 import re
 import periodictable as pt
 
+from ...common import stable_argsort
 from ...plugin import FuseBasePlugin
 
 export, __all__ = strax.exporter()
@@ -135,8 +136,8 @@ class LineageClustering(FuseBasePlugin):
 
             event = geant4_interactions[geant4_interactions["eventid"] == event_id]
 
-            track_id_sort = np.argsort(event[["trackid", "t"]])
-            undo_sort_index = np.argsort(track_id_sort)
+            track_id_sort = stable_argsort(event[["trackid", "t"]])
+            undo_sort_index = stable_argsort(track_id_sort)
             event = event[track_id_sort]
 
             lineage = self.build_lineage_for_event(

--- a/fuse/plugins/pmt_and_daq/pmt_afterpulses.py
+++ b/fuse/plugins/pmt_and_daq/pmt_afterpulses.py
@@ -3,7 +3,7 @@ import numpy as np
 import straxen
 
 from ...dtypes import propagated_photons_fields
-from ...common import pmt_gains
+from ...common import stable_argsort, pmt_gains
 from ...plugin import FuseBasePlugin
 
 export, __all__ = strax.exporter()
@@ -128,7 +128,7 @@ class PMTAfterPulses(FuseBasePlugin):
         s2_photons = None
 
         # Sort all photons by time
-        sortind = np.argsort(merged_photons["time"])
+        sortind = stable_argsort(merged_photons["time"])
         merged_photons = merged_photons[sortind]
 
         _photon_timings = merged_photons["time"]

--- a/fuse/plugins/pmt_and_daq/pmt_response_and_daq.py
+++ b/fuse/plugins/pmt_and_daq/pmt_response_and_daq.py
@@ -489,7 +489,7 @@ def add_current(photon_timings, photon_gains, pulse_left, dt, pmt_current_templa
         return
 
     template_length = len(pmt_current_templates[0])
-    i_photons = np.argsort(photon_timings)
+    i_photons = stable_argsort(photon_timings)
     # Convert photon_timings to int outside this function
     # photon_timings = photon_timings // 1
 

--- a/fuse/plugins/truth_information/event_truth.py
+++ b/fuse/plugins/truth_information/event_truth.py
@@ -64,8 +64,6 @@ class EventTruth(strax.Plugin):
             contributing_cluster_informations = interactions_in_roi[
                 np.isin(interactions_in_roi["cluster_id"], photons_per_event[i]["cluster_id"])
             ]
-            # sort_index = np.argsort(contributing_cluster_informations["cluster_id"])
-            # contributing_cluster_informations = contributing_cluster_informations[sort_index]
             result["total_energy_in_event_truth"][i] = np.sum(
                 contributing_cluster_informations["ed"]
             )

--- a/fuse/plugins/truth_information/peak_truth.py
+++ b/fuse/plugins/truth_information/peak_truth.py
@@ -2,7 +2,7 @@ import numpy as np
 import strax
 import straxen
 
-from ...common import pmt_gains
+from ...common import stable_argsort, pmt_gains
 
 export, __all__ = strax.exporter()
 
@@ -250,7 +250,7 @@ def _get_cluster_information(interactions_in_roi, unique_contributing_clusters):
     contributing_cluster_informations = interactions_in_roi[
         np.isin(interactions_in_roi["cluster_id"], unique_contributing_clusters)
     ]
-    sort_index = np.argsort(contributing_cluster_informations["cluster_id"])
+    sort_index = stable_argsort(contributing_cluster_informations["cluster_id"])
     return contributing_cluster_informations[sort_index]
 
 

--- a/fuse/plugins/truth_information/records_truth.py
+++ b/fuse/plugins/truth_information/records_truth.py
@@ -3,7 +3,7 @@ import straxen
 import numpy as np
 import numba
 
-from ...common import pmt_gains
+from ...common import stable_argsort, pmt_gains
 
 export, __all__ = strax.exporter()
 
@@ -117,7 +117,7 @@ def fill_result_buffer(list_input, result_buffer):
 
 
 def split_photons_by_channel(propagated_photons):
-    sort_index = np.argsort(propagated_photons[["channel", "time"]])
+    sort_index = stable_argsort(propagated_photons[["channel", "time"]])
 
     propagated_photons_sorted = propagated_photons[sort_index]
 
@@ -128,7 +128,7 @@ def split_photons_by_channel(propagated_photons):
 
 
 def split_records_by_channel(records):
-    sort_index = np.argsort(records[["channel", "time"]])
+    sort_index = stable_argsort(records[["channel", "time"]])
 
     records_sorted = records[sort_index]
 


### PR DESCRIPTION
This PR was initiated when I found that the `propagated_s1_photons` and `propagated_s2_photons` are not deterministic, i.e., the result will be a little bit different each time I submit a job.

`np.sort` and `np.argsort` in fuse are only partially changed to `stable_sort` and `stable_argsort`. This PR applies stable sorting to all sorting in fuse.

Depends on https://github.com/AxFoundation/strax/pull/918 and https://github.com/XENONnT/fuse/issues/298