### PR TITLE
Reduce `cut_delayed` to be much less than `np.iinfo(np.int64).max`

### DIFF
--- a/fuse/plugins/micro_physics/input.py
+++ b/fuse/plugins/micro_physics/input.py
@@ -67,7 +67,7 @@ class ChunkInput(FuseBasePlugin):
     )
 
     cut_delayed = straxen.URLConfig(
-        default=9e18,
+        default=1e18,
         type=(int, float),
         help="All interactions happening after this time (including the event time) will be cut",
     )


### PR DESCRIPTION
_Before you submit this PR: make sure to put all XENONnT specific information in a wiki-note as the repo is publicly accessible_

## What does the code in this PR do / what does it improve?

I understand the `cut_delayed` was set as 9e18, which is a bit smaller than `np.iinfo(np.int64).max` (9223372036854775807). But for `strax.sort_by_time` to work, the "maximum" possible time difference can only be about 4.5e18 because:

1. For some reason, `np.sort` can not work when the max time is larger than `np.iinfo(np.int64).max`
2. The placeholder `channel` is conservatively set as `np.ones(len(x))`, so as long as the max time is larger than about 4.5e18, the `strax.sort_by_time` will use `np.sort` rather than `strax.processing.general._sort_by_time_and_channel`.

Also, the 9e18 is too large, is it about 300 years.

## Can you briefly describe how it works?

Set `cut_delayed` as 1e18 so that the `strax.sort_by_time` will always use the fast sorting `_sort_by_time_and_channel`.

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Bump plugin version(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
