### PR TITLE
Fix bug caused by event id time overlapping in `interaction_lineage `

### DIFF
--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -95,7 +95,7 @@ class LineageClustering(FuseBasePlugin):
         if len(geant4_interactions) == 0:
             return np.zeros(0, dtype=self.dtype)
 
-        event_id_sort = stable_argsort(geant4_interactions[["eventid", "t"]])
+        event_id_sort = stable_argsort(geant4_interactions[["eventid", "time", "t"]])
         undo_sort_index = stable_argsort(event_id_sort)
         interactions = geant4_interactions[event_id_sort]
 

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -100,8 +100,8 @@ class LineageClustering(FuseBasePlugin):
         undo_sort_index = stable_argsort(event_id_sort)
         interactions = geant4_interactions[event_id_sort]
 
-        lineage_ids, lineage_trackids, lineage_types, lineage_A, lineage_Z, main_cluster_type = self.build_lineages(
-            interactions
+        lineage_ids, lineage_trackids, lineage_types, lineage_A, lineage_Z, main_cluster_type = (
+            self.build_lineages(interactions)
         )
 
         # The lineage index is now unique per event. We need to make it unique for the whole run

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -95,16 +95,20 @@ class LineageClustering(FuseBasePlugin):
         if len(geant4_interactions) == 0:
             return np.zeros(0, dtype=self.dtype)
 
+        event_id_sort = stable_argsort(geant4_interactions[["eventid", "t"]])
+        undo_sort_index = stable_argsort(event_id_sort)
+        interactions = geant4_interactions[event_id_sort]
+
         lineage_ids, lineage_types, lineage_A, lineage_Z, main_cluster_type = self.build_lineages(
-            geant4_interactions
+            interactions
         )
 
         # The lineage index is now unique per event. We need to make it unique for the whole run
         _, unique_lineage_index = np.unique(
-            (geant4_interactions["eventid"], lineage_ids), axis=1, return_inverse=True
+            (interactions["eventid"], lineage_ids), axis=1, return_inverse=True
         )
 
-        data = np.zeros(len(geant4_interactions), dtype=self.dtype)
+        data = np.zeros(len(interactions), dtype=self.dtype)
         data["lineage_index"] = unique_lineage_index + self.lineages_build
         data["event_lineage_index"] = lineage_ids
         data["lineage_type"] = lineage_types
@@ -112,12 +116,12 @@ class LineageClustering(FuseBasePlugin):
         data["Z"] = lineage_Z
         data["main_cluster_type"] = main_cluster_type
 
-        data["time"] = geant4_interactions["time"]
-        data["endtime"] = geant4_interactions["endtime"]
+        data["time"] = interactions["time"]
+        data["endtime"] = interactions["endtime"]
 
         self.lineages_build = np.max(data["lineage_index"]) + 1
 
-        return data
+        return data[undo_sort_index]
 
     def build_lineages(
         self,


### PR DESCRIPTION
_Before you submit this PR: make sure to put all XENONnT specific information in a wiki-note as the repo is publicly accessible_

## What does the code in this PR do / what does it improve?

Different `eventid` can overlap in time of `geant4_interactions`. `geant4_interactions` is sorted in time, but the returned values of `build_lineages` are sorted in `eventid`.

## Can you briefly describe how it works?

Sort `geant4_interactions` by `eventid` and time, run `build_lineages`, and finally recover the order of `interaction_lineage` according `geant4_interactions`.

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Bump plugin version(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
