### PR TITLE
Break lineage when neutron's `edproc` is Transportation

### DIFF
--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -519,7 +519,7 @@ def is_lineage_broken(
 
     # break neutron lineage
     if parent["type"] == "neutron":
-        if parent["edproc"] in ["hadElastic", "neutronInelastic", "nCapture"]:
+        if parent["edproc"] in ["Transportation", "hadElastic", "neutronInelastic", "nCapture"]:
             return True
 
     # I also want to break the lineage if the interaction happens way after the parent interaction


### PR DESCRIPTION
_Before you submit this PR: make sure to put all XENONnT specific information in a wiki-note as the repo is publicly accessible_

## What does the code in this PR do / what does it improve?

## Can you briefly describe how it works?

## Can you give a minimal working example (or illustrate with a figure)?

_Please include the following if applicable:_
  - [ ] _Update the docstring(s)_
  - [ ] _Bump plugin version(s)_
  - [ ] _Update the documentation_
  - [ ] _Tests to check the (new) code is working as desired._
  - [ ] _Does it solve one of the [GitHub open issues](https://github.com/XENONnT/fuse/issues)?_
