### PR TITLE
Patch photoionization_modifier default value

### DIFF
--- a/fuse/context_utils.py
+++ b/fuse/context_utils.py
@@ -64,8 +64,10 @@ def set_simulation_config_file(context, config_file_name):
                 )
 
             # Special case for the photoionization_modifier
+            # This is because unfortunately we do not track the photoionization
+            # version in the global version.. we use v3 as hardcoded default for now
             if option_key == "photoionization_modifier":
-                context.config[option_key] = option.default
+                context.config[option_key] = option.default.replace("ONLINE", "v3")
 
 
 @URLConfig.register("pattern_map")


### PR DESCRIPTION
As discussed here https://github.com/XENONnT/fuse/pull/52 the photoionization_modifier is special because unfortunately it is not included in the global corrections version for xenonnt. Because of this, its version is not replaced by the apply xedocs configs function. In the past, we had the default set to v2. I did not realise this was intentional (difficult to spot..) so I changed its default to ONLINE in https://github.com/XENONnT/fuse/pull/303.. this did not raise an error in the tests, but with most recent strax straxen we raise an error if there is an online value when xedocs corrections version is set. 
I do not have a good solution for this, but for now, let's go back to the patch we had: hardcoding a version for this correction in fuse. We now do it more explicitly in the config utils and leave ONLINE in the plugin default. 

Temporary solution waiting for a better idea to solve this (like including pi in global, even if we would still need the patch for older global versions). 