### PR TITLE
Implement lce_from_pattern_map function directly in plugin

### DIFF
--- a/fuse/context_utils.py
+++ b/fuse/context_utils.py
@@ -185,16 +185,6 @@ def overwrite_map_from_config(
                 context.set_config({key: config[resource_keys[np.argwhere(matching_keys)[0][0]]]})
 
 
-@URLConfig.register("lce_from_pattern_map")
-def lce_from_pattern_map(map, pmt_mask):
-    """Build a S1 lce correction map from a S1 pattern map."""
-
-    lcemap = deepcopy(map)
-    lcemap.data["map"] = np.sum(lcemap.data["map"][:][:][:], axis=3, keepdims=True, where=pmt_mask)
-    lcemap.__init__(lcemap.data)
-    return lcemap
-
-
 def apply_mc_overrides(context, config_file):
     """Apply config overrides from 'mc_overrides' using from_config."""
     try:

--- a/fuse/plugins/detector_physics/s1_photon_hits.py
+++ b/fuse/plugins/detector_physics/s1_photon_hits.py
@@ -1,5 +1,6 @@
 import strax
 import straxen
+from copy import deepcopy
 
 import numpy as np
 

--- a/fuse/plugins/detector_physics/s1_photon_hits.py
+++ b/fuse/plugins/detector_physics/s1_photon_hits.py
@@ -111,7 +111,7 @@ class S1PhotonHits(FuseBasePlugin):
         )
         lcemap.__init__(lcemap.data)
         self.s1_lce_correction_map = lcemap
-    
+
     def compute(self, interactions_in_roi):
         # Just apply this to clusters with photons
         mask = interactions_in_roi["photons"] > 0
@@ -166,6 +166,3 @@ class S1PhotonHits(FuseBasePlugin):
         n_photon_hits = self.rng.binomial(n=n_photons, p=ly)
 
         return n_photon_hits
-
-
-

--- a/fuse/plugins/detector_physics/s1_photon_hits.py
+++ b/fuse/plugins/detector_physics/s1_photon_hits.py
@@ -102,10 +102,7 @@ class S1PhotonHits(FuseBasePlugin):
 
         self.pmt_mask = np.array(self.gains) > 0  # Converted from to pe (from xedocs by default)
 
-        self.s1_lce_correction_map = lce_from_pattern_map(
-            self.s1_pattern_map,
-            self.pmt_mask
-        )
+        self.s1_lce_correction_map = lce_from_pattern_map(self.s1_pattern_map, self.pmt_mask)
 
     def compute(self, interactions_in_roi):
         # Just apply this to clusters with photons

--- a/fuse/plugins/detector_physics/s1_photon_hits.py
+++ b/fuse/plugins/detector_physics/s1_photon_hits.py
@@ -15,7 +15,7 @@ class S1PhotonHits(FuseBasePlugin):
     """Plugin to simulate the number of detected S1 photons using a S1 light
     collection efficiency map."""
 
-    __version__ = "0.2.2"
+    __version__ = "0.3.0"
 
     depends_on = "microphysics_summary"
     provides = "s1_photon_hits"


### PR DESCRIPTION
Proposal to apply the lce function directly in plugin and not in the url config. 
This is becuase it makes it quite confusing when changin the s1 pattern map config, that the lce is not also updated... 
This way, changin s1 pattern map config makes both changes at the same time, pattern and lce. 

---

To be more clear, there is not change in the implementation. 
Just that now, if changing only s1_pattern_map with st.config, s1 lce would not change.
With this PR (and before <1.5.0), changing s1_pattern_map also changes lce - makes more sense and less prone to errors. 

Thanks to @kboese-mpik for realising this (and sorry for causing you this pain!) 
