### PR TITLE
Make NR flag more flexible

### DIFF
--- a/fuse/plugins/micro_physics/input.py
+++ b/fuse/plugins/micro_physics/input.py
@@ -113,7 +113,8 @@ class ChunkInput(FuseBasePlugin):
     nr_only = straxen.URLConfig(
         default=False,
         type=bool,
-        help="Filter only nuclear recoil events (maximum ER energy deposit according to maximal_er_energy)",
+        help="Filter only nuclear recoil events "
+        "(maximum ER energy deposit according to maximal_er_energy)",
     )
 
     maximal_er_energy = straxen.URLConfig(


### PR DESCRIPTION
This makes the NR flag more flexible by letting the user adjust the maximum ER energy to be included.

ATTENTION: This change will modify all fuse lineages!!!! So merging must be coordinated!