### PR TITLE
Micro clustering for NR sims

### DIFF
--- a/fuse/plugins/micro_physics/microphysics_summary.py
+++ b/fuse/plugins/micro_physics/microphysics_summary.py
@@ -24,10 +24,9 @@ class MicroPhysicsSummary(strax.MergeOnlyPlugin):
     __version__ = "0.1.0"
 
 
-
 @export
 class MicroPhysicsSummaryNRFilter(FuseBasePlugin):
-    """Plugin which filters the microphysics summary for valid NR events"""
+    """Plugin which filters the microphysics summary for valid NR events."""
 
     depends_on = (
         "interactions_in_roi",
@@ -39,7 +38,6 @@ class MicroPhysicsSummaryNRFilter(FuseBasePlugin):
     rechunk_on_save = True
     chunk_target_size_mb = 0.5
 
-    
     provides = "microphysics_summary"
     __version__ = "0.0.2"
 
@@ -54,19 +52,19 @@ class MicroPhysicsSummaryNRFilter(FuseBasePlugin):
         help="Scaled g2 x 0.8 to acocunt for corrections [pe/e]",
     )
 
-    max_s1_area  = straxen.URLConfig(
+    max_s1_area = straxen.URLConfig(
         default=700,
         type=(int, float),
         help="Max S1 area [pe] for NR roi",
     )
-    max_s2_area  = straxen.URLConfig(
-        default=3*10**4,
+    max_s2_area = straxen.URLConfig(
+        default=3 * 10**4,
         type=(int, float),
         help="Max S2 area [pe] for NR roi",
     )
 
     def infer_dtype(self):
-        dtypes = [self.deps[d].dtype_for(d) for d in sorted(self.depends_on) ]
+        dtypes = [self.deps[d].dtype_for(d) for d in sorted(self.depends_on)]
         return strax.merged_dtype(dtypes)
 
     def compute(self, interactions_in_roi):
@@ -79,70 +77,66 @@ class MicroPhysicsSummaryNRFilter(FuseBasePlugin):
             self.max_s2_area,
         )
 
-
-        microphysics_summary = np.zeros(
-            len(interactions_in_roi),
-            dtype=self.dtype
-        )
-        strax.copy_to_buffer(interactions_in_roi, microphysics_summary, '_copy_microphysics')
+        microphysics_summary = np.zeros(len(interactions_in_roi), dtype=self.dtype)
+        strax.copy_to_buffer(interactions_in_roi, microphysics_summary, "_copy_microphysics")
         microphysics_summary = microphysics_summary[vertex_to_keep == 1]
         return microphysics_summary
-
 
 
 @numba.njit
 def filter_events(mps, g1, g2, max_s1, max_s2):
     """Small function to filter microphysics for valide NR events.
-    We cut all events which are overshadowed by other events outside 
-    of our ROI excluding delayed deexcitations. To account for missing
+
+    We cut all events which are overshadowed by other events outside of
+    our ROI excluding delayed deexcitations. To account for missing
     detector corrections one should scale g1/g2 down.
     """
 
-    event_ids = np.unique(mps['eventid'])
-    
+    event_ids = np.unique(mps["eventid"])
+
     vertex_to_keep = np.ones(len(mps))
-    
+
     vertex_i = 0
-    
+
     for event_i in event_ids:
         start_index = vertex_i
         max_photons = 0
         max_electrons = 0
         prompt_photons = 0
         number_of_nr_interactions = 0
-        start_time = mps['time'][vertex_i]
-    
+        start_time = mps["time"][vertex_i]
+
         for vertex_i in range(start_index, len(mps)):
             vertex = mps[vertex_i]
-    
-            _is_a_new_event = event_i < vertex['eventid']
+
+            _is_a_new_event = event_i < vertex["eventid"]
             if _is_a_new_event:
                 # Next event starts break for loop and check next event
                 break
 
             # Is prompt vertex:
-            _is_prompt = (vertex['time'] - start_time) < 200 # ns
+            _is_prompt = (vertex["time"] - start_time) < 200  # ns
             if _is_prompt:
-                prompt_photons += vertex['photons']
+                prompt_photons += vertex["photons"]
 
             # Ignore and drop vertex if too much delayed within event:
-            _vertex_is_delayed = (vertex['time'] - start_time) > 3_000_000 # ms
+            _vertex_is_delayed = (vertex["time"] - start_time) > 3_000_000  # ms
             if _vertex_is_delayed:
                 vertex_to_keep[vertex_i] = 0
                 continue
-    
-            max_photons = max(max_photons, vertex['photons'])
-            max_electrons = max(max_electrons, vertex['electrons'])
-            _is_nr = vertex['nestid'] == 0
+
+            max_photons = max(max_photons, vertex["photons"])
+            max_electrons = max(max_electrons, vertex["electrons"])
+            _is_nr = vertex["nestid"] == 0
             if _is_nr:
                 number_of_nr_interactions += 1
 
         # Check if the largest interaction is still within ROI:
         _is_in_nr_roi = (
-            (max_photons*g1 < max_s1)
-            & (max_electrons*g2 < max_s2)
+            (max_photons * g1 < max_s1)
+            & (max_electrons * g2 < max_s2)
             & (number_of_nr_interactions > 0)
-            & (prompt_photons*g1 < max_s1)
+            & (prompt_photons * g1 < max_s1)
         )
 
         if not _is_in_nr_roi:


### PR DESCRIPTION
Adds new microclustering plugin which enables the user to cut events for NR sims if the event would be outside of the cS1 and cS2 ROI. Makes selection on simple loose criteria without being too presumptuous.   