### PR TITLE
Add elife to cs2 corrections

### DIFF
--- a/fuse/plugins/processing/corrected_areas.py
+++ b/fuse/plugins/processing/corrected_areas.py
@@ -30,7 +30,7 @@ class CorrectedAreasMC(straxen.CorrectedAreas):
         if "cs2_wo_timecorr" in result.dtype.names:
             result["cs2"] = result["cs2_wo_timecorr"]
             result["alt_cs2"] = result["alt_cs2_wo_timecorr"]
-        elif "cs2_w_bias_xy" in result.dtype.names:
+        elif "cs2_w_bias_xy_elife" in result.dtype.names:
             result["cs2"] = result["cs2_w_bias_xy_elife"]
             result["alt_cs2"] = result["alt_cs2_w_bias_xy_elife"]
         else:


### PR DESCRIPTION
Adding also elife to the cs2 corrections.

In #363 and #364 from last month we changed the way the cs2 field in fuse is overwritten from straxen corrected areas. We do not want to include time dependent corrections but we do want to include the elife correction (because its from a model, not from relative time). We also include xy and peak bias corrections. 

In the past we used to  set cs2 of fuse to cs2_wo_timecorr, and this included both xy and elife  ([see here](https://github.com/XENONnT/straxen/blob/bdaa023e4385ac88ecd31eec6d6d28b33a364012/straxen/plugins/events/corrected_areas.py#L253)) (note the peak bias correction did not exist yet). 

Not with this PR we set cs2 in fuse to cs2_w_bias_xy_elife. 