### PR TITLE
Fixes to get the public context running again

### DIFF
--- a/fuse/context_utils.py
+++ b/fuse/context_utils.py
@@ -115,6 +115,17 @@ def modify_s2_pattern_map(
     return s2_pattern_map
 
 
+@URLConfig.register("lce_from_pattern_map")
+def lce_from_pattern_map(map, pmt_mask):
+    """Build a S1 lce correction map from a S1 pattern map."""
+
+    lcemap = deepcopy(map)
+    lcemap.data["map"] = np.sum(lcemap.data["map"][:][:][:], axis=3, keepdims=True, where=pmt_mask)
+    lcemap.__init__(lcemap.data)
+    return lcemap
+
+
+
 # Probably not needed!
 @URLConfig.register("simple_load")
 def load(data):
@@ -130,15 +141,24 @@ def from_config(config_name, key):
         raise ValueError(f"Key {key} not found in {config_name}")
     return config[key]
 
-
 class DummyMap:
     """Return constant results with length equal to that of the input and
     second dimensions (constand correction) user-defined."""
 
     def __init__(self, const, shape=()):
-        self.const = float(const)
-        self.shape = shape
-        self.data = {"map": np.ones(shape)}
+
+        # The normal case where the user provides a single number for the constant correction
+        if isinstance(const, str):
+            self.const = float(const)
+            self.shape = shape
+            self.data = {"map": np.ones(shape) * self.const}
+
+        # The case where the map was modified outside, e.g. to build a LCE map from s1 pattern map
+        if isinstance(const, dict):
+            # Just pick the first value of map as the constant, since all values should be the same after modification
+            self.const = const["map"].flat[0]
+            self.shape = const["map"].shape
+            self.data = {"map": const["map"]}
 
     def __call__(self, x, **kwargs):
         shape = [len(x)] + list(self.shape)

--- a/fuse/plugins/detector_physics/electron_drift.py
+++ b/fuse/plugins/detector_physics/electron_drift.py
@@ -213,11 +213,12 @@ class ElectronDrift(FuseBasePlugin):
 
             self.diffusion_longitudinal_map = _rz_map
 
-        csys = self.fdc_map_fuse.coordinate_system
-        rmin, rmax = csys[:, 0].min(), csys[:, 0].max()
-        zmin, zmax = csys[:, 1].min(), csys[:, 1].max()
-        self.fdc_map_r_bounds = (rmin, rmax)
-        self.fdc_map_z_bounds = (zmin, zmax)
+        if self.field_distortion_model == "comsol":
+            csys = self.fdc_map_fuse.coordinate_system
+            rmin, rmax = csys[:, 0].min(), csys[:, 0].max()
+            zmin, zmax = csys[:, 1].min(), csys[:, 1].max()
+            self.fdc_map_r_bounds = (rmin, rmax)
+            self.fdc_map_z_bounds = (zmin, zmax)
 
     def compute(self, interactions_in_roi):
         # Just apply this to clusters with photons

--- a/fuse/plugins/detector_physics/s1_photon_hits.py
+++ b/fuse/plugins/detector_physics/s1_photon_hits.py
@@ -73,6 +73,14 @@ class S1PhotonHits(FuseBasePlugin):
         help="S1 LCE correction map",
     )
 
+    s1_lce_correction_map = straxen.URLConfig(
+        default="lce_from_pattern_map:plugin.s1_pattern_map?"
+        "&pmt_mask=plugin.pmt_mask",
+        cache=True,
+        help="S1 LCE correction map",
+    )
+    
+
     p_double_pe_emision = straxen.URLConfig(
         default="take://resource://"
         "SIMULATION_CONFIG_FILE.json?&fmt=json"
@@ -102,15 +110,6 @@ class S1PhotonHits(FuseBasePlugin):
         )
 
         self.pmt_mask = np.array(self.gains) > 0  # Converted from to pe (from xedocs by default)
-
-        # Build LCE map from s1 pattern map
-        lcemap = deepcopy(self.s1_pattern_map)
-        # AT: this scaling with mast is redundant to `make_patternmap`, but keep it in for now
-        lcemap.data["map"] = np.sum(
-            lcemap.data["map"][:][:][:], axis=3, keepdims=True, where=self.pmt_mask
-        )
-        lcemap.__init__(lcemap.data)
-        self.s1_lce_correction_map = lcemap
 
     def compute(self, interactions_in_roi):
         # Just apply this to clusters with photons

--- a/fuse/plugins/detector_physics/s2_photon_propagation.py
+++ b/fuse/plugins/detector_physics/s2_photon_propagation.py
@@ -427,7 +427,7 @@ class S2PhotonPropagationBase(FuseBaseDownChunkingPlugin):
             t1, t3 = 0, 0
 
         delay = self.rng.choice([t1, t3], size, replace=True, p=[singlet_ratio, 1 - singlet_ratio])
-        return self.rng.exponential(1, size) * delay
+        return (self.rng.exponential(1, size) * delay).astype(np.int64)
 
     def photon_timings(self, positions, n_photons, _photon_channels):
         raise NotImplementedError
@@ -798,4 +798,4 @@ def _luminescence_timings_simple(
         # linear interp on monotonic CDF y/y[-1] → t
         emission_time[s:e] = np.interp(probs, y / y[-1], t)
 
-    return emission_time
+    return emission_time.astype(np.int64)


### PR DESCRIPTION
This PR aims to get the public context running again.  The most important changes are summarized below.

### S1 LCE Correction Map Refactor

* Added a new function `lce_from_pattern_map` in `context_utils.py` to build an S1 LCE correction map directly from an S1 pattern map, and registered it as a `URLConfig` endpoint. This makes LCE map construction modular and reusable.
* Updated the `S1PhotonHits` plugin to use the new `lce_from_pattern_map` function via a `straxen.URLConfig` entry for `s1_lce_correction_map`, simplifying configuration and improving maintainability.
* Removed the manual LCE map construction from the `setup` method in `S1PhotonHits`, as it is now handled by the new `URLConfig` mechanism.
* The goal of this change is to simplify the usage of DummyMaps for the LCE map. The functionality remains unchanged.

### Map Handling Improvements

* Enhanced the `DummyMap` class to support initialization from a map dictionary, allowing it to be used seamlessly with maps produced or modified outside the class (e.g., by `lce_from_pattern_map`).

### Data Type Consistency

* Ensured that timing arrays returned by `singlet_triplet_delays` and `_luminescence_timings_simple` in `s2_photon_propagation.py` are always of type `np.int64`, preventing downstream type errors. [[1]](diffhunk://#diff-41f8934c8d558b833da2d4c27d53903368c448151671dd3d10dffbded2b48555L430-R430) [[2]](diffhunk://#diff-41f8934c8d558b833da2d4c27d53903368c448151671dd3d10dffbded2b48555L801-R801)

### Other

* Added a missing conditional for the `comsol` field distortion model in `electron_drift.py` to ensure it is only used when the comsol option is actually used.