### PR TITLE
Fix get_parent same-time-tag bug in LineageClustering

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
     rev: v1.7.7
     hooks:
     -   id: docformatter
+        language_version: python3.12
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.16.1

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -27,7 +27,7 @@ class LineageClustering(FuseBasePlugin):
     and its parent.
     """
 
-    __version__ = "0.0.5"
+    __version__ = "0.0.6"
 
     depends_on = "geant4_interactions"
 
@@ -343,7 +343,16 @@ def precompute_parent_lookup(event):
 
 
 def get_parent(event_interactions, event_lineage, particle, parent_lookup):
-    """Returns the parent particle and its lineage of the given particle."""
+    """Returns the parent particle and its lineage of the given particle.
+
+    When multiple parent interactions share the same time tag (e.g. a fast
+    gamma that Compton-scatters and photoabsorbs within G4's sub-ns time-tag
+    precision), tie-break by spatial proximity to the daughter's creation
+    position. Without the spatial tie-break, the original time-cut + array-
+    last logic mis-attributes the daughter's parent to whichever same-time
+    step happens to be last in the array, even when that step is several cm
+    away at a different vertex (see e.g. K40 / Co60 single-gamma decays).
+    """
     parent_id = parent_lookup.get(particle["trackid"], None)
     if parent_id is None:
         return None, None
@@ -361,10 +370,25 @@ def get_parent(event_interactions, event_lineage, particle, parent_lookup):
         parent_to_return = np.argmin(abs(parent_interactions["t"] - particle["t"]))
         return parent_interactions[parent_to_return], parent_lineages[parent_to_return]
 
-    return (
-        parent_interactions[parent_interactions_time_cut][-1],
-        parent_lineages[parent_interactions_time_cut][-1],
+    # Among parents with t <= particle.t, pick the latest time and then
+    # tie-break by spatial proximity if multiple steps share that latest time.
+    candidates = parent_interactions[parent_interactions_time_cut]
+    candidate_lineages = parent_lineages[parent_interactions_time_cut]
+    t_max = candidates["t"].max()
+    same_time_mask = candidates["t"] == t_max
+    if same_time_mask.sum() == 1:
+        idx = int(np.where(same_time_mask)[0][0])
+        return candidates[idx], candidate_lineages[idx]
+
+    same_time = candidates[same_time_mask]
+    same_time_lineages = candidate_lineages[same_time_mask]
+    distances = np.sqrt(
+        (same_time["x"] - particle["x"]) ** 2
+        + (same_time["y"] - particle["y"]) ** 2
+        + (same_time["z"] - particle["z"]) ** 2
     )
+    nearest = int(np.argmin(distances))
+    return same_time[nearest], same_time_lineages[nearest]
 
 
 def is_particle_in_lineage(lineage):

--- a/fuse/plugins/micro_physics/lineage_cluster.py
+++ b/fuse/plugins/micro_physics/lineage_cluster.py
@@ -345,13 +345,14 @@ def precompute_parent_lookup(event):
 def get_parent(event_interactions, event_lineage, particle, parent_lookup):
     """Returns the parent particle and its lineage of the given particle.
 
-    When multiple parent interactions share the same time tag (e.g. a fast
-    gamma that Compton-scatters and photoabsorbs within G4's sub-ns time-tag
-    precision), tie-break by spatial proximity to the daughter's creation
-    position. Without the spatial tie-break, the original time-cut + array-
-    last logic mis-attributes the daughter's parent to whichever same-time
-    step happens to be last in the array, even when that step is several cm
-    away at a different vertex (see e.g. K40 / Co60 single-gamma decays).
+    When multiple parent interactions share the same time tag (e.g. a
+    fast gamma that Compton-scatters and photoabsorbs within G4's sub-ns
+    time-tag precision), tie-break by spatial proximity to the
+    daughter's creation position. Without the spatial tie-break, the
+    original time-cut + array- last logic mis-attributes the daughter's
+    parent to whichever same-time step happens to be last in the array,
+    even when that step is several cm away at a different vertex (see
+    e.g. K40 / Co60 single-gamma decays).
     """
     parent_id = parent_lookup.get(particle["trackid"], None)
     if parent_id is None:


### PR DESCRIPTION
## Fix `get_parent` same-time-tag bug in `LineageClustering`

### Summary

Tie-break by spatial proximity to the daughter's creation position when multiple parent interactions in `lineage_cluster.get_parent` share the same time tag.

For fast γ events that Compton-scatter at one site and photoabsorb at another within G4's sub-ns time-tag precision (~0.1 ns of travel time, bit-identical `float64` `t`), the original time-cut + array-last logic returned the *last* same-time parent step in array order — which can be the wrong vertex. The Compton e⁻ daughter at site A then inherited the lineage of the γ's photoabsorbtion step at site B, collapsing the two physical scatter sites into a single cluster.

### What's affected

Empirically the bug only flips event-level SS/MS classification for **single-γ-decay** isotopes (K40, Co60). Cascade chains (Th, U, Ra) and β-only sources (Pb212 with `nucleusLimits` excluding daughter chain) are unaffected, because either (a) cascade γ's have distinct decay-time tags so `get_parent`'s time-cut already disambiguates, or (b) there's no γ Compton+phot pair to trigger the same-time-tag tie in the first place.

For K40/Co60, ~65 % of physically multi-scatter events end up reclassified as single-scatter, biasing the MS templates by ~50 % vs WFsim.

### Validation

5 isotopes × 20 jobs × 100k primaries each (InnerCryostatFlange for K40/Co60/Th232/Ra226; WholeLXe for Pb212; SR0 Fermi-Dirac SS/MS classifier):

| isotope | topology | vanilla MS-ratio vs WFsim 2026 | **patched MS-ratio vs WFsim 2026** |
|---|---|---:|---:|
| K40   | 1.46 MeV single γ        | 0.385 | **1.006** ✓ |
| Co60  | 1.17+1.33 MeV 2-γ cascade| 0.351 | **0.998** ✓ |
| Th232 | chain cascade γ's        | 0.997 | 0.996 |
| Ra226 | α + 186 keV γ + chain    | 1.002 | 1.000 |
| Pb212 | intrinsic β (no γ)       | 1.000 | **1.000 — bit-identical h5** |

Single-event spot check (K40 `g4id=39232`):

| | site A (-35.6, -21.8, -0.2) | site B (-33.2, -18.4, -0.6) | alt_cs2_wo_timecorr | SS/MS |
|---|---:|---:|---:|:---:|
| WFsim epix     | 423.27 keV | 1036.87 keV | 154,972 PE | MS |
| Vanilla fuse   | 0.06 keV | 1460.76 keV | 128 PE | SS ✗ |
| **Patched fuse** | **423.95 keV** | **1036.87 keV** | **189,862 PE** | **MS ✓** |

### The diff

```python
# Among parents with t <= particle.t, pick the latest time and then
# tie-break by spatial proximity if multiple steps share that latest time.
candidates = parent_interactions[parent_interactions_time_cut]
candidate_lineages = parent_lineages[parent_interactions_time_cut]
t_max = candidates["t"].max()
same_time_mask = candidates["t"] == t_max
if same_time_mask.sum() == 1:
    idx = int(np.where(same_time_mask)[0][0])
    return candidates[idx], candidate_lineages[idx]

same_time = candidates[same_time_mask]
same_time_lineages = candidate_lineages[same_time_mask]
distances = np.sqrt(
    (same_time["x"] - particle["x"]) ** 2
    + (same_time["y"] - particle["y"]) ** 2
    + (same_time["z"] - particle["z"]) ** 2
)
nearest = int(np.argmin(distances))
return same_time[nearest], same_time_lineages[nearest]
```

The existing nearest-in-time fallback (when no parent step satisfies `t <= particle.t`) is preserved unchanged.

### Alternatives considered

I also prototyped and validated two position-free alternatives:

- **Process-match**: `daughter.creaproc == parent.edproc` (G4's causal mapping). Closes ~85 % of the gap.
- **Precompute hybrid**: `{trackid: parent_step_index}` map computed once per event using process-match → spatial fallback, making `get_parent` O(1). Also ~85 %.

Both are causally explicit but converge on the same coverage. The spatial tie-break in this PR catches the additional ~15 % of edge cases (daughters whose `creaproc` isn't directly in the parent's `edproc` set, e.g. secondary brems and cascaded photo-absorptions). A true hybrid (process-match prefilter on the same-time-max candidate set with spatial tie-break inside) is the principled long-term refinement — worth a follow-up PR but not blocking.

### Test plan

- [ ] Existing fuse unit tests pass
- [ ] Spot-check K40 `g4id=39232` produces the 423/1037 keV split documented above
- [ ] Cross-isotope MS-rate ratios vs WFsim land within statistics of the table above on a re-run
<img width="1624" height="496" alt="Screenshot 2026-05-10 at 20 20 46" src="https://github.com/user-attachments/assets/b2b0a0c3-9f5c-43c6-838f-c48300cc96a7" />
<img width="1751" height="846" alt="ces_sum_comparison" src="https://github.com/user-attachments/assets/5f80390e-baca-477d-accb-d2c77e532652" />

